### PR TITLE
Cleanup DiscordPage.xaml.cs

### DIFF
--- a/Unicord.Universal/App.xaml
+++ b/Unicord.Universal/App.xaml
@@ -89,8 +89,8 @@
             </Style>
 
             <Style x:Key="IconButtonStyle" TargetType="Button" BasedOn="{StaticResource StretchyIconButtonStyle}">
-                <Setter Property="Width" Value="42"/>
-                <Setter Property="MinHeight" Value="42"/>
+                <Setter Property="Width" Value="40"/>
+                <Setter Property="MinHeight" Value="40"/>
             </Style>
 
             <Style x:Key="StretchyIconToggleButtonStyle" TargetType="ToggleButton" BasedOn="{StaticResource ToggleButtonRevealStyle}">
@@ -103,8 +103,8 @@
             </Style>
 
             <Style x:Key="IconToggleButtonStyle" TargetType="ToggleButton" BasedOn="{StaticResource StretchyIconToggleButtonStyle}">
-                <Setter Property="Width" Value="42"/>
-                <Setter Property="Height" Value="42"/>
+                <Setter Property="Width" Value="40"/>
+                <Setter Property="Height" Value="40"/>
             </Style>
 
         </ResourceDictionary>

--- a/Unicord.Universal/App.xaml
+++ b/Unicord.Universal/App.xaml
@@ -85,7 +85,7 @@
 
             <Style x:Key="StretchyIconButtonStyle" TargetType="Button" BasedOn="{StaticResource CleanButtonStyle}">
                 <Setter Property="FontFamily" Value="Segoe MDL2 Assets"/>
-                <Setter Property="FontSize" Value="18"/>
+                <Setter Property="FontSize" Value="16"/>
             </Style>
 
             <Style x:Key="IconButtonStyle" TargetType="Button" BasedOn="{StaticResource StretchyIconButtonStyle}">
@@ -96,7 +96,7 @@
             <Style x:Key="StretchyIconToggleButtonStyle" TargetType="ToggleButton" BasedOn="{StaticResource ToggleButtonRevealStyle}">
                 <Setter Property="Background" Value="Transparent"/>
                 <Setter Property="FontFamily" Value="Segoe MDL2 Assets"/>
-                <Setter Property="FontSize" Value="18"/>
+                <Setter Property="FontSize" Value="16"/>
                 <Setter Property="BorderThickness" Value="1"/>
                 <Setter Property="UseLayoutRounding" Value="True"/>
                 <Setter Property="Template" Value="{StaticResource IconToggleButtonTemplate}"/>

--- a/Unicord.Universal/Commands/BanCommand.cs
+++ b/Unicord.Universal/Commands/BanCommand.cs
@@ -21,7 +21,7 @@ namespace Unicord.Universal.Commands
                 if (member.IsCurrent)
                     return false;
 
-                if (!Tools.CheckRoleHeirarchy(member.Guild.CurrentMember, member))
+                if (!Tools.CheckRoleHierarchy(member.Guild.CurrentMember, member))
                     return false;
 
                 return member.Guild.CurrentMember.PermissionsIn(null).HasPermission(Permissions.BanMembers);

--- a/Unicord.Universal/Commands/ChangeNicknameCommand.cs
+++ b/Unicord.Universal/Commands/ChangeNicknameCommand.cs
@@ -24,7 +24,7 @@ namespace Unicord.Universal.Commands
                     return true;
                 }
 
-                if (permissions.HasFlag(Permissions.ManageNicknames) && Tools.CheckRoleHeirarchy(member.Guild.CurrentMember, member))
+                if (permissions.HasFlag(Permissions.ManageNicknames) && Tools.CheckRoleHierarchy(member.Guild.CurrentMember, member))
                 {
                     return true;
                 }

--- a/Unicord.Universal/Commands/EditChannelCommand.cs
+++ b/Unicord.Universal/Commands/EditChannelCommand.cs
@@ -4,6 +4,7 @@ using DSharpPlus;
 using DSharpPlus.Entities;
 using Unicord.Universal.Pages;
 using Unicord.Universal.Pages.Management;
+using Unicord.Universal.Services;
 using Windows.UI.Xaml;
 
 namespace Unicord.Universal.Commands
@@ -42,7 +43,7 @@ namespace Unicord.Universal.Commands
                 var page = Window.Current.Content.FindChild<DiscordPage>();
                 if (page != null)
                 {
-                    page.OpenCustomPane(typeof(ChannelEditPage), channel);
+                    OverlayService.GetForCurrentView().ShowOverlay<ChannelEditPage>(channel);
                 }
             }
         }

--- a/Unicord.Universal/Commands/KickCommand.cs
+++ b/Unicord.Universal/Commands/KickCommand.cs
@@ -21,7 +21,7 @@ namespace Unicord.Universal.Commands
                 if (member.IsCurrent)
                     return false;
 
-                if (!Tools.CheckRoleHeirarchy(member.Guild.CurrentMember, member))
+                if (!Tools.CheckRoleHierarchy(member.Guild.CurrentMember, member))
                     return false;
 
                 return member.Guild.CurrentMember.PermissionsIn(null).HasPermission(Permissions.KickMembers);

--- a/Unicord.Universal/Commands/MessageUserCommand.cs
+++ b/Unicord.Universal/Commands/MessageUserCommand.cs
@@ -4,6 +4,7 @@ using System.Windows.Input;
 using DSharpPlus;
 using DSharpPlus.Entities;
 using Unicord.Universal.Pages;
+using Unicord.Universal.Services;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media.Animation;
 
@@ -58,11 +59,8 @@ namespace Unicord.Universal.Commands
                     {
                         page.HideOverlay();
 
-                        var discordPage = page.FindChild<DiscordPage>();
-                        if (discordPage != null)
-                        {
-                            discordPage.Navigate(channel, new DrillInNavigationTransitionInfo());
-                        }
+                        var service = DiscordNavigationService.GetForCurrentView();
+                        await service.NavigateAsync(channel);
                     }
                 }
             }

--- a/Unicord.Universal/Controls/Embeds/EmbedVideoControl.xaml.cs
+++ b/Unicord.Universal/Controls/Embeds/EmbedVideoControl.xaml.cs
@@ -1,11 +1,12 @@
-using DSharpPlus.Entities;
-using Microsoft.QueryStringDotNET;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Web;
+using DSharpPlus.Entities;
+using Microsoft.QueryStringDotNET;
+using Unicord.Universal.Services;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
 using Windows.UI.Xaml;
@@ -68,17 +69,14 @@ namespace Unicord.Universal.Controls.Embeds
 
         private void Browser_ContainsFullScreenElementChanged(WebView sender, object args)
         {
-            var page = this.FindParent<MainPage>();
+            var service = FullscreenService.GetForCurrentView();
             if (sender.ContainsFullScreenElement)
             {
-                if (page != null)
-                {
-                    page.EnterFullscreen(sender, content);
-                }
+                service.EnterFullscreen(sender, content);
             }
             else
             {
-                page.LeaveFullscreen(sender, content);
+                service.LeaveFullscreen(sender, content);
             }
         }
 

--- a/Unicord.Universal/Controls/EmotePicker.xaml
+++ b/Unicord.Universal/Controls/EmotePicker.xaml
@@ -25,7 +25,7 @@
 
                 <Grid Width="24" Height="24" Margin="0,0,10,0">
                     <lib:PersonPicture x:Name="iconImage" Visibility="{x:Bind Key.IconUrl, Converter={StaticResource HideOnNullConverter}}" Width="24" Height="24" ProfilePicture="{x:Bind Key.IconUrl}" DisplayName="{x:Bind Key.Name}" />
-                    <TextBlock x:Name="iconText" Visibility="{x:Bind Key.IconCharacter, Converter={StaticResource HideOnNullConverter}}" VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="18" Text="{x:Bind Key.IconCharacter}" />
+                    <TextBlock x:Name="iconText" Visibility="{x:Bind Key.IconCharacter, Converter={StaticResource HideOnNullConverter}}" VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="16" Text="{x:Bind Key.IconCharacter}" />
                 </Grid>
 
                 <TextBlock FontSize="14" VerticalAlignment="Center" Grid.Column="1" Text="{x:Bind Key.Name}" />

--- a/Unicord.Universal/Controls/MessageViewer.xaml
+++ b/Unicord.Universal/Controls/MessageViewer.xaml
@@ -196,10 +196,11 @@
                 </Grid>
 
                 <wam:MarkdownTextBlock x:Name="markdown"
-                                           Channel="{Binding Channel}"
-                                           IsTextSelectionEnabled="False"
-                                           Text="{Binding Content}"
-                                           WrapCodeBlock="True"/>
+                                       UseLayoutRounding="False"
+                                       Channel="{Binding Channel}"
+                                        IsTextSelectionEnabled="False"
+                                        Text="{Binding Content}"
+                                        WrapCodeBlock="True"/>
             </Grid>
             <StackPanel x:Name="embeds" Grid.Row="2" />
         </Grid>

--- a/Unicord.Universal/Controls/MessageViewer.xaml.cs
+++ b/Unicord.Universal/Controls/MessageViewer.xaml.cs
@@ -254,7 +254,7 @@ namespace Unicord.Universal.Controls
 
         private bool CheckPermission(Permissions permission)
         {
-            return _currentMember?.IsOwner == true || _permissions.HasPermission(permission) && Tools.CheckRoleHeirarchy(_currentMember, _member);
+            return _currentMember?.IsOwner == true || _permissions.HasPermission(permission) && Tools.CheckRoleHierarchy(_currentMember, _member);
         }
 
         private void profileMenuItem_Click(object sender, RoutedEventArgs e)

--- a/Unicord.Universal/Controls/UploadItemsControl.xaml.cs
+++ b/Unicord.Universal/Controls/UploadItemsControl.xaml.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Controls;
 using Unicord.Universal.Models;
 using Unicord.Universal.Pages;
+using Unicord.Universal.Services;
 using Unicord.Universal.Utilities;
 using Windows.Foundation.Metadata;
 using Windows.Storage;
@@ -214,7 +215,7 @@ namespace Unicord.Universal.Controls
             bigModel.FileUploads.Remove(model);
             bigModel.FileUploads.Add(newModel);
 
-            this.FindParent<DiscordPage>().OpenCustomPane(typeof(VideoEditor), newModel);
+            OverlayService.GetForCurrentView().ShowOverlay<VideoEditor>(newModel);
         }
 
         private void EditButton_Loaded(object sender, RoutedEventArgs e)

--- a/Unicord.Universal/MainPage.xaml
+++ b/Unicord.Universal/MainPage.xaml
@@ -12,7 +12,8 @@
     xmlns:dialogs="using:Unicord.Universal.Dialogs"
     xmlns:controls1="using:Unicord.Universal.Controls"
     xmlns:w1903="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 8)"
-    mc:Ignorable="d" Loaded="Page_Loaded" Unloaded="Page_Unloaded" NavigationCacheMode="Required"
+    mc:Ignorable="d" Loaded="Page_Loaded" Unloaded="Page_Unloaded"
+    NavigationCacheMode="Required"
     Background="{ThemeResource MainBackgroundBrush}">
     <Page.Resources>
         <CircleEase x:Key="CircleEase" EasingMode="EaseInOut"/>

--- a/Unicord.Universal/MainPage.xaml
+++ b/Unicord.Universal/MainPage.xaml
@@ -10,11 +10,15 @@
     xmlns:fc="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:dialogs="using:Unicord.Universal.Dialogs"
-    xmlns:controls1="using:Unicord.Universal.Controls" 
+    xmlns:controls1="using:Unicord.Universal.Controls"
+    xmlns:w1903="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 8)"
     mc:Ignorable="d" Loaded="Page_Loaded" Unloaded="Page_Unloaded" NavigationCacheMode="Required"
     Background="{ThemeResource MainBackgroundBrush}">
     <Page.Resources>
-        <CircleEase x:Key="ease" EasingMode="EaseInOut"/>
+        <CircleEase x:Key="CircleEase" EasingMode="EaseInOut"/>
+        
+        <ExponentialEase x:Key="EaseEnter" EasingMode="EaseOut" Exponent="7" />
+        <ExponentialEase x:Key="EaseExit" EasingMode="EaseIn" Exponent="4.5" />
 
         <Storyboard x:Name="showConnecting" x:Key="showConnecting">
 
@@ -22,29 +26,29 @@
                              Storyboard.TargetName="connectingOverlay"
                              Storyboard.TargetProperty="Opacity"
                              Duration="0:0:0.50"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseExit}"/>
 
             <DoubleAnimation From="1" To="0.85" 
                              Storyboard.TargetName="mainScale"
                              Storyboard.TargetProperty="(ScaleTransform.ScaleX)"
                              Duration="0:0:0.40"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseExit}"/>
             <DoubleAnimation From="1" To="0.85" 
                              Storyboard.TargetName="mainScale"
                              Storyboard.TargetProperty="(ScaleTransform.ScaleY)"
                              Duration="0:0:0.40"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseExit}"/>
 
             <DoubleAnimation From="1.25" To="1" 
                              Storyboard.TargetName="connectingScale"
                              Storyboard.TargetProperty="(ScaleTransform.ScaleX)"
                              Duration="0:0:0.40"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseEnter}"/>
             <DoubleAnimation From="1.25" To="1" 
                              Storyboard.TargetName="connectingScale"
                              Storyboard.TargetProperty="(ScaleTransform.ScaleY)"
                              Duration="0:0:0.40"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseEnter}"/>
 
         </Storyboard>
         <Storyboard x:Name="hideConnecting" x:Key="hideConnecting"
@@ -53,29 +57,29 @@
                              Storyboard.TargetName="connectingOverlay"
                              Storyboard.TargetProperty="Opacity"
                              Duration="0:0:0.50"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseEnter}"/>
 
             <DoubleAnimation To="1" 
                              Storyboard.TargetName="mainScale"
                              Storyboard.TargetProperty="(ScaleTransform.ScaleX)"
                              Duration="0:0:0.40"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseEnter}"/>
             <DoubleAnimation To="1" 
                              Storyboard.TargetName="mainScale"
                              Storyboard.TargetProperty="(ScaleTransform.ScaleY)"
                              Duration="0:0:0.40"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseEnter}"/>
 
             <DoubleAnimation To="1.25" 
                              Storyboard.TargetName="connectingScale"
                              Storyboard.TargetProperty="(ScaleTransform.ScaleX)"
                              Duration="0:0:0.40"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseExit}"/>
             <DoubleAnimation To="1.25" 
                              Storyboard.TargetName="connectingScale"
                              Storyboard.TargetProperty="(ScaleTransform.ScaleY)"
                              Duration="0:0:0.40"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseExit}"/>
         </Storyboard>
 
         <Storyboard x:Name="showContent" x:Key="showContent">
@@ -84,18 +88,18 @@
                              Storyboard.TargetName="contentOverlay"
                              Storyboard.TargetProperty="Opacity"
                              Duration="0:0:0.25"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseEnter}"/>
 
             <DoubleAnimation From="0.85" To="1" 
                              Storyboard.TargetName="contentScale"
                              Storyboard.TargetProperty="(ScaleTransform.ScaleX)"
                              Duration="0:0:0.20"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseEnter}"/>
             <DoubleAnimation From="0.85" To="1" 
                              Storyboard.TargetName="contentScale"
                              Storyboard.TargetProperty="(ScaleTransform.ScaleY)"
                              Duration="0:0:0.20"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseEnter}"/>
 
         </Storyboard>
         <Storyboard x:Name="hideContent" x:Key="hideContent"
@@ -104,18 +108,18 @@
                              Storyboard.TargetName="contentOverlay"
                              Storyboard.TargetProperty="Opacity"
                              Duration="0:0:0.25"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseExit}"/>
 
             <DoubleAnimation From="1" To="0.85" 
                              Storyboard.TargetName="contentScale"
                              Storyboard.TargetProperty="(ScaleTransform.ScaleX)"
                              Duration="0:0:0.15"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseExit}"/>
             <DoubleAnimation From="1" To="0.85" 
                              Storyboard.TargetName="contentScale"
                              Storyboard.TargetProperty="(ScaleTransform.ScaleY)"
                              Duration="0:0:0.15"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseExit}"/>
         </Storyboard>
 
         <Storyboard x:Name="showUserOverlay" x:Key="showUserOverlay">
@@ -124,18 +128,18 @@
                              Storyboard.TargetName="userInfoPopup"
                              Storyboard.TargetProperty="Opacity"
                              Duration="0:0:0.25"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseEnter}"/>
 
             <DoubleAnimation From="0.85" To="1" 
                              Storyboard.TargetName="userInfoScale"
                              Storyboard.TargetProperty="(ScaleTransform.ScaleX)"
                              Duration="0:0:0.20"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseEnter}"/>
             <DoubleAnimation From="0.85" To="1" 
                              Storyboard.TargetName="userInfoScale"
                              Storyboard.TargetProperty="(ScaleTransform.ScaleY)"
                              Duration="0:0:0.20"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseEnter}"/>
 
         </Storyboard>
         <Storyboard x:Name="hideUserOverlay" x:Key="hideUserOverlay"
@@ -144,22 +148,62 @@
                              Storyboard.TargetName="userInfoPopup"
                              Storyboard.TargetProperty="Opacity"
                              Duration="0:0:0.25"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseExit}"/>
 
             <DoubleAnimation From="1" To="0.85" 
                              Storyboard.TargetName="userInfoScale"
                              Storyboard.TargetProperty="(ScaleTransform.ScaleX)"
                              Duration="0:0:0.20"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseExit}"/>
             <DoubleAnimation From="1" To="0.85" 
                              Storyboard.TargetName="userInfoScale"
                              Storyboard.TargetProperty="(ScaleTransform.ScaleY)"
                              Duration="0:0:0.20"
-                             EasingFunction="{StaticResource ease}"/>
+                             EasingFunction="{StaticResource EaseExit}"/>
+        </Storyboard>
+
+        <Storyboard x:Name="ShowOverlayStoryboard" x:Key="ShowOverlayStoryboard">
+
+            <DoubleAnimation From="0" To="1"
+                             Storyboard.TargetName="CustomOverlayGrid"
+                             Storyboard.TargetProperty="Opacity"
+                             Duration="0:0:0.25"
+                             EasingFunction="{StaticResource EaseEnter}"/>
+
+            <DoubleAnimation From="0.85" To="1" 
+                             Storyboard.TargetName="CustomPaneScale"
+                             Storyboard.TargetProperty="(ScaleTransform.ScaleX)"
+                             Duration="0:0:0.20"
+                             EasingFunction="{StaticResource EaseEnter}"/>
+            <DoubleAnimation From="0.85" To="1" 
+                             Storyboard.TargetName="CustomPaneScale"
+                             Storyboard.TargetProperty="(ScaleTransform.ScaleY)"
+                             Duration="0:0:0.20"
+                             EasingFunction="{StaticResource EaseEnter}"/>
+
+        </Storyboard>
+        <Storyboard x:Name="HideOverlayStoryboard" x:Key="HideOverlayStoryboard"
+                    Completed="HideOverlayStoryboard_Completed">
+            <DoubleAnimation From="1" To="0"
+                             Storyboard.TargetName="CustomOverlayGrid"
+                             Storyboard.TargetProperty="Opacity"
+                             Duration="0:0:0.25"
+                             EasingFunction="{StaticResource EaseExit}"/>
+
+            <DoubleAnimation From="1" To="0.85" 
+                             Storyboard.TargetName="CustomPaneScale"
+                             Storyboard.TargetProperty="(ScaleTransform.ScaleX)"
+                             Duration="0:0:0.20"
+                             EasingFunction="{StaticResource EaseExit}"/>
+            <DoubleAnimation From="1" To="0.85" 
+                             Storyboard.TargetName="CustomPaneScale"
+                             Storyboard.TargetProperty="(ScaleTransform.ScaleY)"
+                             Duration="0:0:0.20"
+                             EasingFunction="{StaticResource EaseExit}"/>
         </Storyboard>
     </Page.Resources>
     <Grid x:Name="everything">
-        <Grid UseLayoutRounding="False">
+        <Grid>
             <Grid x:Name="mainContent" RenderTransformOrigin="0.5, 0.5">
                 <Grid.RenderTransform>
                     <ScaleTransform x:Name="mainScale" ScaleX="1" ScaleY="1"/>
@@ -185,6 +229,8 @@
                                       IsHorizontalRailEnabled="False"
                                       HorizontalScrollBarVisibility="Auto"
                                       HorizontalScrollMode="Enabled" 
+                                      HorizontalAlignment="Stretch"
+                                      VerticalAlignment="Stretch"
                                       ZoomMode="Enabled">
                             <Image x:Name="attachmentImage" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                         </ScrollViewer>
@@ -222,7 +268,22 @@
                     <dialogs:ProfileOverlay x:Name="userInfoOverlay" Visibility="Visible"/>
                 </Grid>
             </Grid>
-            
+
+            <Grid x:Name="CustomOverlayGrid"
+                  Opacity="0"
+                  Background="{ThemeResource OverlayBackdrop}" 
+                  Visibility="Collapsed">
+                <Grid x:Name="CustomContainer"
+                      RenderTransformOrigin="0.5,0.5">
+                    <Grid.RenderTransform>
+                        <TransformGroup>
+                            <ScaleTransform x:Name="CustomPaneScale" ScaleX="1" ScaleY="1" />
+                        </TransformGroup>
+                    </Grid.RenderTransform>
+                    <Frame x:Name="CustomOverlayFrame" />
+                </Grid>
+            </Grid>
+
             <Grid x:Name="fullscreenCanvas" Background="{ThemeResource OverlayBackdrop}" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Visibility="Collapsed"/>
             
             <Grid x:Name="connectingOverlay" Visibility="Collapsed" Opacity="0" RenderTransformOrigin="0.5, 0.5" Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">

--- a/Unicord.Universal/MainPage.xaml.cs
+++ b/Unicord.Universal/MainPage.xaml.cs
@@ -26,6 +26,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Navigation;
+using Windows.UI.Xaml.Hosting;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
 
@@ -38,6 +39,7 @@ namespace Unicord.Universal
     {
         public bool IsOverlayShown { get; internal set; }
         public Frame RootFrame => rootFrame;
+        public Frame CustomFrame => CustomOverlayFrame;
 
         private ShareOperation _shareOperation;
         internal MainPageArgs Arguments { get; private set; }
@@ -150,11 +152,6 @@ namespace Unicord.Universal
             userInfoPopup.Visibility = Visibility.Visible;
 
             showUserOverlay.Begin();
-        }
-
-        internal void ShowGuildOverlay(DiscordGuild guild, bool animate)
-        {
-            // TODO: Guild Overlay
         }
 
         private async Task OnFirstDiscordReady(ReadyEventArgs e)
@@ -420,6 +417,23 @@ namespace Unicord.Universal
                 e.Handled = true;
                 hideUserOverlay.Begin();
             }
+        }
+
+        public void ShowCustomOverlay()
+        {
+            CustomOverlayGrid.Visibility = Visibility.Visible;
+            ShowOverlayStoryboard.Begin();
+        }
+
+        public void HideCustomOverlay()
+        {
+            HideOverlayStoryboard.Begin();
+        }
+
+
+        private void HideOverlayStoryboard_Completed(object sender, object e)
+        {
+            CustomOverlayGrid.Visibility = Visibility.Collapsed;
         }
     }
 }

--- a/Unicord.Universal/MainPage.xaml.cs
+++ b/Unicord.Universal/MainPage.xaml.cs
@@ -45,8 +45,6 @@ namespace Unicord.Universal
         private RoutedEventHandler _saveHandler;
         private RoutedEventHandler _shareHandler;
         private bool _isReady;
-        private FrameworkElement _fullscreenElement;
-        private Panel _fullscreenParent;
 
         public MainPage()
         {
@@ -393,51 +391,6 @@ namespace Unicord.Universal
             hideUserOverlay.Begin();
         }
 
-        internal void EnterFullscreen(FrameworkElement element, Panel parent)
-        {
-            var view = ApplicationView.GetForCurrentView();
-            view.TryEnterFullScreenMode();
-
-            fullscreenCanvas.Visibility = Visibility.Visible;
-            DisplayInformation.AutoRotationPreferences = DisplayOrientations.Landscape | DisplayOrientations.LandscapeFlipped | DisplayOrientations.Portrait;
-
-            _fullscreenElement = element;
-            _fullscreenParent = parent;
-
-            parent.Children.Remove(element);
-            fullscreenCanvas.Children.Add(element);
-            element.Width = double.NaN;
-            element.Height = double.NaN;
-        }
-
-        internal void LeaveFullscreen()
-        {
-            ApplicationView.GetForCurrentView().ExitFullScreenMode();
-            DisplayInformation.AutoRotationPreferences = DisplayOrientations.Portrait;
-
-            _fullscreenElement = null;
-            _fullscreenParent = null;
-
-            fullscreenCanvas.Children.Clear();
-            fullscreenCanvas.Visibility = Visibility.Collapsed;
-        }
-
-        internal void LeaveFullscreen(FrameworkElement element, Panel parent)
-        {
-            ApplicationView.GetForCurrentView().ExitFullScreenMode();
-            DisplayInformation.AutoRotationPreferences = DisplayOrientations.Portrait;
-
-            fullscreenCanvas.Children.Remove(element);
-            parent.Children.Insert(0, element);
-            element.Width = double.NaN;
-            element.Height = double.NaN;
-
-            _fullscreenElement = null;
-            _fullscreenParent = null;
-
-            fullscreenCanvas.Visibility = Visibility.Collapsed;
-        }
-
         private void Pane_Showing(InputPane sender, InputPaneVisibilityEventArgs args)
         {
             everything.Margin = new Thickness(0, 0, 0, args.OccludedRect.Height);
@@ -452,20 +405,6 @@ namespace Unicord.Universal
 
         private void Navigation_BackRequested(object sender, BackRequestedEventArgs e)
         {
-            if (fullscreenCanvas.Visibility == Visibility.Visible)
-            {
-                if (_fullscreenElement != null && _fullscreenParent != null)
-                {
-                    LeaveFullscreen(_fullscreenElement, _fullscreenParent);
-                }
-                else
-                {
-                    LeaveFullscreen();
-                }
-
-                e.Handled = true;
-            }
-
             if (contentOverlay.Visibility == Visibility.Visible)
             {
                 e.Handled = true;

--- a/Unicord.Universal/MainPage.xaml.cs
+++ b/Unicord.Universal/MainPage.xaml.cs
@@ -1,11 +1,11 @@
-﻿using DSharpPlus;
-using DSharpPlus.Entities;
-using DSharpPlus.EventArgs;
-using Microsoft.Toolkit.Uwp.Helpers;
-using Microsoft.Services.Store.Engagement;
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using DSharpPlus;
+using DSharpPlus.Entities;
+using DSharpPlus.EventArgs;
+using Microsoft.Services.Store.Engagement;
+using Microsoft.Toolkit.Uwp.Helpers;
 using Unicord.Universal.Integration;
 using Unicord.Universal.Models;
 using Unicord.Universal.Pages;
@@ -23,10 +23,10 @@ using Windows.UI.StartScreen;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Hosting;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Navigation;
-using Windows.UI.Xaml.Hosting;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
 
@@ -52,7 +52,6 @@ namespace Unicord.Universal
         public MainPage()
         {
             InitializeComponent();
-            NavigationCacheMode = NavigationCacheMode.Disabled;
         }
 
         protected override async void OnNavigatedTo(NavigationEventArgs e)
@@ -156,11 +155,14 @@ namespace Unicord.Universal
 
         private async Task OnFirstDiscordReady(ReadyEventArgs e)
         {
-            _isReady = true;
+            if (!_isReady)
+            {
+                App.Discord.Ready += OnDiscordReady;
+                App.Discord.Resumed += OnDiscordResumed;
+                App.Discord.SocketClosed += OnDiscordDisconnected;
+            }
 
-            App.Discord.Ready += OnDiscordReady;
-            App.Discord.Resumed += OnDiscordResumed;
-            App.Discord.SocketClosed += OnDiscordDisconnected;
+            _isReady = true;
 
             // TODO: This doesn't work?
             //await e.Client.UpdateStatusAsync(userStatus: UserStatus.Online);

--- a/Unicord.Universal/Models/ChannelEditViewModel.cs
+++ b/Unicord.Universal/Models/ChannelEditViewModel.cs
@@ -26,8 +26,8 @@ namespace Unicord.Universal.Models
         public bool NSFW { get; set; }
 
         public bool IsVoice => _channel.Type == ChannelType.Voice;
-        public double Userlimit { get; set; }
-        public double Bitrate { get; set; }
+        public int Userlimit { get; set; }
+        public int Bitrate { get; set; }
 
         public Task SaveChangesAsync()
         {

--- a/Unicord.Universal/Models/DiscordPageModel.cs
+++ b/Unicord.Universal/Models/DiscordPageModel.cs
@@ -62,6 +62,7 @@ namespace Unicord.Universal.Models
         public DiscordDmChannel SelectedDM { get => _selectedDM; internal set => OnPropertySet(ref _selectedDM, value); }
         public DiscordGuild SelectedGuild { get => _selectedGuild; internal set => OnPropertySet(ref _selectedGuild, value); }
         public bool IsFriendsSelected { get => _isFriendsSelected; internal set => OnPropertySet(ref _isFriendsSelected, value); }
+        public DiscordDmChannel PreviousDM { get; internal set; }
 
         private Task OnMessageCreated(MessageCreateEventArgs e)
         {

--- a/Unicord.Universal/Models/DiscordPageModel.cs
+++ b/Unicord.Universal/Models/DiscordPageModel.cs
@@ -17,6 +17,10 @@ namespace Unicord.Universal.Models
         private readonly SynchronizationContext _synchronisation;
         private VoiceConnectionModel _voiceModel;
         private DiscordUser _currentUser;
+        private DiscordChannel _currentChannel;
+        private DiscordDmChannel _selectedDM;
+        private DiscordGuild _selectedGuild;
+        private bool _isFriendsSelected;
 
         public DiscordPageModel()
         {
@@ -52,11 +56,12 @@ namespace Unicord.Universal.Models
 
         public DiscordUser CurrentUser { get => _currentUser; set => OnPropertySet(ref _currentUser, value); }
         public VoiceConnectionModel VoiceModel { get => _voiceModel; set => OnPropertySet(ref _voiceModel, value); }
-        public DiscordChannel CurrentChannel { get; internal set; }
         public bool Navigating { get; internal set; }
-        public DiscordDmChannel SelectedDM { get; internal set; }
-        public DiscordGuild SelectedGuild { get; internal set; }
-        public bool IsFriendsSelected { get; internal set; }
+
+        public DiscordChannel CurrentChannel { get => _currentChannel; internal set => OnPropertySet(ref _currentChannel, value); }
+        public DiscordDmChannel SelectedDM { get => _selectedDM; internal set => OnPropertySet(ref _selectedDM, value); }
+        public DiscordGuild SelectedGuild { get => _selectedGuild; internal set => OnPropertySet(ref _selectedGuild, value); }
+        public bool IsFriendsSelected { get => _isFriendsSelected; internal set => OnPropertySet(ref _isFriendsSelected, value); }
 
         private Task OnMessageCreated(MessageCreateEventArgs e)
         {

--- a/Unicord.Universal/Models/DiscordPageModel.cs
+++ b/Unicord.Universal/Models/DiscordPageModel.cs
@@ -56,6 +56,7 @@ namespace Unicord.Universal.Models
         public bool Navigating { get; internal set; }
         public DiscordDmChannel SelectedDM { get; internal set; }
         public DiscordGuild SelectedGuild { get; internal set; }
+        public bool IsFriendsSelected { get; internal set; }
 
         private Task OnMessageCreated(MessageCreateEventArgs e)
         {

--- a/Unicord.Universal/Models/DiscordPageModel.cs
+++ b/Unicord.Universal/Models/DiscordPageModel.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using DSharpPlus.Entities;
+using DSharpPlus.EventArgs;
 using Unicord.Universal.Voice;
 
 namespace Unicord.Universal.Models
@@ -11,15 +14,114 @@ namespace Unicord.Universal.Models
     // TODO: Move functionaliy from DiscordPage.xaml.cs into this class
     class DiscordPageModel : PropertyChangedBase
     {
+        private readonly SynchronizationContext _synchronisation;
         private VoiceConnectionModel _voiceModel;
         private DiscordUser _currentUser;
 
         public DiscordPageModel()
         {
+            _synchronisation = SynchronizationContext.Current;
+
+            Guilds = new ObservableCollection<DiscordGuild>();
+            UnreadDMs = new ObservableCollection<DiscordDmChannel>();
             CurrentUser = App.Discord.CurrentUser;
+
+            var guildPositions = App.Discord.UserSettings?.GuildPositions;
+            foreach (var guild in App.Discord.Guilds.Values.OrderBy(g => guildPositions?.IndexOf(g.Id) ?? 0))
+            {
+                Guilds.Add(guild);
+            }
+
+            foreach (var dm in App.Discord.PrivateChannels.Values)
+            {
+                if (dm.ReadState.MentionCount > 0)
+                {
+                    UnreadDMs.Add(dm);
+                }
+            }
+
+            App.Discord.MessageCreated += OnMessageCreated;
+            App.Discord.MessageAcknowledged += OnMessageAcknowledged;
+            App.Discord.GuildCreated += OnGuildCreated;
+            App.Discord.GuildDeleted += OnGuildDeleted;
+            App.Discord.UserSettingsUpdated -= OnUserSettingsUpdated;
         }
+
+        public ObservableCollection<DiscordGuild> Guilds { get; }
+        public ObservableCollection<DiscordDmChannel> UnreadDMs { get; }
 
         public DiscordUser CurrentUser { get => _currentUser; set => OnPropertySet(ref _currentUser, value); }
         public VoiceConnectionModel VoiceModel { get => _voiceModel; set => OnPropertySet(ref _voiceModel, value); }
+        public DiscordChannel CurrentChannel { get; internal set; }
+        public bool Navigating { get; internal set; }
+        public DiscordDmChannel SelectedDM { get; internal set; }
+        public DiscordGuild SelectedGuild { get; internal set; }
+
+        private Task OnMessageCreated(MessageCreateEventArgs e)
+        {
+            if (e.Channel is DiscordDmChannel dm)
+            {
+                UpdateReadState(dm);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private Task OnMessageAcknowledged(MessageAcknowledgeEventArgs e)
+        {
+            if (e.Channel is DiscordDmChannel dm)
+            {
+                UpdateReadState(dm);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private void UpdateReadState(DiscordDmChannel dm)
+        {
+            if (dm.ReadState?.MentionCount > 0 && !UnreadDMs.Contains(dm))
+            {
+                _synchronisation.Post((o) => UnreadDMs.Insert(0, dm), null);
+            }
+            else if (dm.ReadState?.MentionCount == 0)
+            {
+                _synchronisation.Post((o) => UnreadDMs.Remove(dm), null);
+            }
+        }
+
+        private Task OnGuildCreated(GuildCreateEventArgs e)
+        {
+            if (!Guilds.Contains(e.Guild))
+            {
+                _synchronisation.Post(d => Guilds.Insert(0, e.Guild), null);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private Task OnGuildDeleted(GuildDeleteEventArgs e)
+        {
+            _synchronisation.Post(d => Guilds.Remove(e.Guild), null);
+            return Task.CompletedTask;
+        }
+
+        private Task OnUserSettingsUpdated(UserSettingsUpdateEventArgs e)
+        {
+            var guildPositions = App.Discord.UserSettings?.GuildPositions;
+            if (!Guilds.Select(g => g.Id).SequenceEqual(guildPositions))
+            {
+                for (var i = 0; i < guildPositions.Count; i++)
+                {
+                    var id = guildPositions[i];
+                    var guild = Guilds[i];
+                    if (id != guild.Id)
+                    {
+                        _synchronisation.Post((o) => Guilds.Move(Guilds.IndexOf(Guilds.First(g => g.Id == id)), i), null);
+                    }
+                }
+            }
+
+            return Task.CompletedTask;
+        }
     }
 }

--- a/Unicord.Universal/Models/MediaSettingsModel.cs
+++ b/Unicord.Universal/Models/MediaSettingsModel.cs
@@ -15,7 +15,7 @@ namespace Unicord.Universal.Models
 
         public int ProcessingAlgorithm
         {
-            get => (int)App.RoamingSettings.Read(VIDEO_PROCESSING, MediaVideoProcessingAlgorithm.MrfCrf444);
+            get => (int)App.RoamingSettings.Read(VIDEO_PROCESSING, MediaVideoProcessingAlgorithm.Default);
             set => App.RoamingSettings.Save(VIDEO_PROCESSING, (MediaTranscodeOptions)value);
         }
 

--- a/Unicord.Universal/Package.appxmanifest
+++ b/Unicord.Universal/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap4="http://schemas.microsoft.com/appx/manifest/uap/windows10/4" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="24101WamWooWamRD.Unicord" Publisher="CN=0F22111D-EDF0-42F0-B58D-26C4C5C5054B" Version="1.6.8.0" />
+  <Identity Name="24101WamWooWamRD.Unicord" Publisher="CN=0F22111D-EDF0-42F0-B58D-26C4C5C5054B" Version="1.6.9.0" />
   <mp:PhoneIdentity PhoneProductId="5783aabf-3049-421f-ae1d-e88bd89018f2" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>ms-resource:AppDisplayName</DisplayName>

--- a/Unicord.Universal/Package.appxmanifest
+++ b/Unicord.Universal/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap4="http://schemas.microsoft.com/appx/manifest/uap/windows10/4" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="24101WamWooWamRD.Unicord" Publisher="CN=0F22111D-EDF0-42F0-B58D-26C4C5C5054B" Version="1.6.7.0" />
+  <Identity Name="24101WamWooWamRD.Unicord" Publisher="CN=0F22111D-EDF0-42F0-B58D-26C4C5C5054B" Version="1.6.8.0" />
   <mp:PhoneIdentity PhoneProductId="5783aabf-3049-421f-ae1d-e88bd89018f2" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>ms-resource:AppDisplayName</DisplayName>

--- a/Unicord.Universal/Pages/ChannelPage.xaml
+++ b/Unicord.Universal/Pages/ChannelPage.xaml
@@ -408,6 +408,9 @@
                             ReorderMode="Disabled"
                             SelectionChanged="MessageList_SelectionChanged"
                             ShowsScrollingPlaceholders="False"
+                            ScrollViewer.IsVerticalRailEnabled="True"
+                            ScrollViewer.HorizontalScrollMode="Disabled"
+                            ScrollViewer.IsHorizontalScrollChainingEnabled="True"
                             SelectionMode="None">
                             <ListView.ItemsPanel>
                                 <ItemsPanelTemplate>
@@ -612,7 +615,7 @@
                                 Grid.Column="2"
                                 Click="emoteButton_Click"
                                 Content="&#xED54;"
-                                FontSize="18"
+                                FontSize="16"
                                 Style="{ThemeResource IconToggleButtonStyle}"
                                 Visibility="{Binding CanSend, Converter={StaticResource BoolVisibilityConverter}}">
                             </ToggleButton>

--- a/Unicord.Universal/Pages/ChannelPage.xaml
+++ b/Unicord.Universal/Pages/ChannelPage.xaml
@@ -28,35 +28,35 @@
         
         <CircleEase x:Key="EaseMovement" EasingMode="EaseInOut" />
 
-        <Storyboard x:Name="showPhotoPicker" Completed="ShowPhotoPicker_Completed">
+        <Storyboard x:Name="ShowPhotoPicker" Completed="ShowPhotoPicker_Completed">
             <DoubleAnimation
                 EasingFunction="{StaticResource EaseIn}"
-                Storyboard.TargetName="photoTransform"
+                Storyboard.TargetName="PhotoTransform"
                 Storyboard.TargetProperty="Y"
                 To="0"
                 Duration="00:00:00.50" />
         </Storyboard>
-        <Storyboard x:Name="hidePhotoPicker" Completed="HidePhotoPicker_Completed">
+        <Storyboard x:Name="HidePhotoPicker" Completed="HidePhotoPicker_Completed">
             <DoubleAnimation
                 EasingFunction="{StaticResource EaseOut}"
-                Storyboard.TargetName="photoTransform"
+                Storyboard.TargetName="PhotoTransform"
                 Storyboard.TargetProperty="Y"
                 To="200"
                 Duration="00:00:00.15" />
         </Storyboard>
 
-        <Storyboard x:Name="showUploadPanel" Completed="ShowUploadPanel_Completed">
+        <Storyboard x:Name="ShowUploadPanel" Completed="ShowUploadPanel_Completed">
             <DoubleAnimation
                 EasingFunction="{StaticResource EaseIn}"
-                Storyboard.TargetName="uploadsTransform"
+                Storyboard.TargetName="UploadsTransform"
                 Storyboard.TargetProperty="Y"
                 To="0"
                 Duration="00:00:00.50" />
         </Storyboard>
-        <Storyboard x:Name="hideUploadPanel" Completed="HideUploadPanel_Completed">
+        <Storyboard x:Name="HideUploadPanel" Completed="HideUploadPanel_Completed">
             <DoubleAnimation
                 EasingFunction="{StaticResource EaseOut}"
-                Storyboard.TargetName="uploadsTransform"
+                Storyboard.TargetName="UploadsTransform"
                 Storyboard.TargetProperty="Y"
                 To="200"
                 Duration="00:00:00.15" />
@@ -197,13 +197,13 @@
             </Grid.ColumnDefinitions>
 
             <Grid
-                x:Name="sidebarGrid"
+                x:Name="SidebarGrid"
                 Width="276"
-                Padding="{Binding Padding, ElementName=topGrid}"
+                Padding="{Binding Padding, ElementName=TopGrid}"
                 HorizontalAlignment="Right"
                 Background="{ThemeResource SidebarSecondaryAcrylicWindowBrush}"
                 Visibility="Collapsed">
-                <Frame x:Name="sidebarFrame" />
+                <Frame x:Name="SidebarFrame" />
             </Grid>
 
             <controls:DropShadowPanel Style="{ThemeResource DropShadowPanelStyle}">
@@ -218,7 +218,7 @@
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
-                    <Grid x:Name="topGrid" VerticalAlignment="Top" Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}">
+                    <Grid x:Name="TopGrid" VerticalAlignment="Top" Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
@@ -243,16 +243,16 @@
                                 </Grid.ColumnDefinitions>
 
                                 <!--  because VisualStateManager is wank  -->
-                                <Grid x:Name="showSidebarButtonContainer" Margin="0,0,-4,0">
+                                <Grid x:Name="ShowSidebarButtonContainer" Margin="0,0,-4,0">
                                     <Button
-                                        x:Name="showSidebarButton"
+                                        x:Name="ShowSidebarButton"
                                         Click="ShowSidebarButton_Click"
                                         Content="&#xE700;"
                                         Style="{ThemeResource IconButtonStyle}" />
                                 </Grid>
 
                                 <Ellipse
-                                    x:Name="userImage"
+                                    x:Name="UserImage"
                                     Grid.Column="1"
                                     Width="24"
                                     Height="24"
@@ -265,7 +265,7 @@
                                 </Ellipse>
 
                                 <TextBlock
-                                    x:Name="header"
+                                    x:Name="Header"
                                     Grid.Column="2"
                                     Margin="8,0,8,0"
                                     VerticalAlignment="Center"
@@ -320,7 +320,7 @@
                                     Style="{ThemeResource IconButtonStyle}"
                                     ToolTipService.ToolTip="Edit Channel" />-->
                                 <ui:DropDownButton
-                                    x:Name="newWindowButton"
+                                    x:Name="NewWindowButton"
                                     x:Uid="/ChannelPage/NewWindowButton"
                                     Content="&#xE78B;"
                                     Style="{ThemeResource IconButtonStyle}"
@@ -335,24 +335,24 @@
                                 </ui:DropDownButton>
 
                                 <ToggleButton
-                                    x:Name="muteButton"
+                                    x:Name="MuteButton"
                                     x:Uid="/ChannelPage/MuteButton"
                                     Content="&#xE74F;"
                                     IsChecked="{Binding Channel.Muted, Mode=TwoWay}"
                                     Style="{ThemeResource IconToggleButtonStyle}"/>
                                 <Button
-                                    x:Name="searchButton"
+                                    x:Name="SearchButton"
                                     x:Uid="/ChannelPage/SearchButton"
                                     Content="&#xE721;"
                                     Style="{ThemeResource IconButtonStyle}"/>
                                 <Button
-                                    x:Name="pinsButton"
+                                    x:Name="PinsButton"
                                     x:Uid="/ChannelPage/PinsButton"
                                     Click="pinsButton_Click"
                                     Content="&#xE718;"
                                     Style="{ThemeResource IconButtonStyle}"/>
                                 <Button
-                                    x:Name="userListButton"
+                                    x:Name="UserListButton"
                                     x:Uid="/ChannelPage/UserListButton"
                                     Click="UserListButton_Click"
                                     Content="&#xE716;"
@@ -374,13 +374,13 @@
                                 </StackPanel.RenderTransform>
 
                                 <Button
-                                    x:Name="deleteAllButton"
+                                    x:Name="DeleteAllButton"
                                     x:Uid="/ChannelPage/DeleteAllButton"
                                     Click="DeleteAllButton_Click"
                                     Content="&#xE74D;"
                                     Style="{ThemeResource IconButtonStyle}"/>
                                 <Button
-                                    x:Name="closeEditButton"
+                                    x:Name="CloseEditButton"
                                     x:Uid="/ChannelPage/CloseEditButton"
                                     Click="CloseEditButton_Click"
                                     Content="&#xE711;"
@@ -390,18 +390,18 @@
 
                         </Grid>
                         <ProgressBar
-                            x:Name="loadingProgress"
+                            x:Name="LoadingProgress"
                             Grid.Row="1"
                             Visibility="Collapsed" />
                         <ProgressBar
-                            x:Name="uploadProgress"
+                            x:Name="UploadProgress"
                             Grid.Row="2"
                             Visibility="Collapsed" />
                     </Grid>
 
                     <Grid Grid.Row="1">
                         <ListView
-                            x:Name="messageList"
+                            x:Name="MessageList"
                             IncrementalLoadingThreshold="15"
                             ItemTemplateSelector="{StaticResource MessageTemplateSelector}"
                             ItemsSource="{Binding Messages}"
@@ -429,7 +429,7 @@
                             </ListView.ItemContainerStyle>
                         </ListView>
                         <StackPanel
-                            x:Name="noMessages"
+                            x:Name="NoMessages"
                             Margin="16"
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center"
@@ -442,22 +442,22 @@
                     
                     <Grid Grid.Row="2">
                         <controls1:UploadItemsControl
-                            x:Name="uploadItems"
+                            x:Name="UploadItems"
                             Height="150"
                             Visibility="Collapsed"
                             IsEnabled="{Binding ShowUploads, UpdateSourceTrigger=PropertyChanged}">
                             <controls1:UploadItemsControl.RenderTransform>
-                                <TranslateTransform x:Name="uploadsTransform" Y="250" />
+                                <TranslateTransform x:Name="UploadsTransform" Y="250" />
                             </controls1:UploadItemsControl.RenderTransform>
                         </controls1:UploadItemsControl>
 
                         <Grid
-                            x:Name="photoPicker"
+                            x:Name="PhotoPicker"
                             Height="150"
                             Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
                             Visibility="Collapsed">
                             <Grid.RenderTransform>
-                                <TranslateTransform x:Name="photoTransform" Y="200" />
+                                <TranslateTransform x:Name="PhotoTransform" Y="200" />
                             </Grid.RenderTransform>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" />
@@ -470,7 +470,7 @@
                                     <RowDefinition Height="*" />
                                 </Grid.RowDefinitions>
                                 <Button
-                                    x:Name="openPopoutButton"
+                                    x:Name="OpenPopoutButton"
                                     x:Uid="/ChannelPage/OpenPopoutButton"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Stretch"
@@ -478,7 +478,7 @@
                                     Content="&#xE8A7;"
                                     Style="{ThemeResource StretchyIconButtonStyle}" />
                                 <Button
-                                    x:Name="openLocalButton"
+                                    x:Name="OpenLocalButton"
                                     x:Uid="/ChannelPage/OpenLocalButton"
                                     Grid.Row="2"
                                     HorizontalAlignment="Stretch"
@@ -489,7 +489,7 @@
                             </Grid>
 
                             <ListView
-                                x:Name="photosList"
+                                x:Name="PhotosList"
                                 Grid.Column="1"
                                 ShowsScrollingPlaceholders="False"
                                 SingleSelectionFollowsFocus="False"
@@ -519,7 +519,7 @@
                             </ListView>
 
                             <ProgressRing
-                                x:Name="loadingImagesRing"
+                                x:Name="LoadingImagesRing"
                                 Grid.Column="1"
                                 Width="42"
                                 Height="42"
@@ -529,7 +529,7 @@
                     </Grid>
 
                     <Grid
-                        x:Name="footerGrid"
+                        x:Name="FooterGrid"
                         Grid.Row="3"
                         Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}">
                         <Grid.RowDefinitions>
@@ -557,7 +557,7 @@
                         </ItemsControl>
 
                         <ProgressBar
-                            x:Name="slowModeTimeout"
+                            x:Name="SlowModeTimeout"
                             Grid.Row="2"
                             Maximum="{Binding PerUserRateLimit}"
                             Visibility="{Binding ShowSlowModeTimeout, Converter={StaticResource BoolVisibilityConverter}}"
@@ -575,14 +575,14 @@
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <Button
-                                x:Name="uploadButton"
+                                x:Name="UploadButton"
                                 Click="uploadButton_Click"
                                 Content="&#xE898;"
                                 Visibility="{Binding CanUpload}"
                                 Style="{ThemeResource IconButtonStyle}" />
 
                             <TextBox
-                                x:Name="messageTextBox"
+                                x:Name="MessageTextBox"
                                 Grid.Column="1"
                                 MaxHeight="90"
                                 Padding="10"
@@ -608,7 +608,7 @@
                                 Visibility="{Binding ShowSlowMode, Converter={StaticResource BoolVisibilityConverter}}" />
 
                             <ToggleButton
-                                x:Name="emoteButton"
+                                x:Name="EmoteButton"
                                 Grid.Column="2"
                                 Click="emoteButton_Click"
                                 Content="&#xED54;"
@@ -617,7 +617,7 @@
                                 Visibility="{Binding CanSend, Converter={StaticResource BoolVisibilityConverter}}">
                             </ToggleButton>
                             <Button
-                                x:Name="sendButton"
+                                x:Name="SendButton"
                                 Grid.Column="3"
                                 Click="sendButton_Click"
                                 Content="&#xE724;"
@@ -638,8 +638,8 @@
                     </VisualState.StateTriggers>
 
                     <VisualState.Setters>
-                        <Setter Target="showSidebarButton.Visibility" Value="Collapsed" />
-                        <Setter Target="sidebarGrid.(Grid.Column)" Value="1" />
+                        <Setter Target="ShowSidebarButton.Visibility" Value="Collapsed" />
+                        <Setter Target="SidebarGrid.(Grid.Column)" Value="1" />
                         <Setter Target="ContentTransform.X" Value="0" />
                     </VisualState.Setters>
                 </VisualState>
@@ -650,8 +650,8 @@
                     </VisualState.StateTriggers>
 
                     <VisualState.Setters>
-                        <Setter Target="showSidebarButton.Visibility" Value="Collapsed" />
-                        <Setter Target="sidebarGrid.(Grid.Column)" Value="0" />
+                        <Setter Target="ShowSidebarButton.Visibility" Value="Collapsed" />
+                        <Setter Target="SidebarGrid.(Grid.Column)" Value="0" />
                     </VisualState.Setters>
                 </VisualState>
 
@@ -661,8 +661,8 @@
                     </VisualState.StateTriggers>
 
                     <VisualState.Setters>
-                        <Setter Target="showSidebarButton.Visibility" Value="Visible" />
-                        <Setter Target="sidebarGrid.(Grid.Column)" Value="0" />
+                        <Setter Target="ShowSidebarButton.Visibility" Value="Visible" />
+                        <Setter Target="SidebarGrid.(Grid.Column)" Value="0" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Unicord.Universal/Pages/ChannelPage.xaml
+++ b/Unicord.Universal/Pages/ChannelPage.xaml
@@ -467,7 +467,7 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
 
-                            <Grid Width="42" Margin="0,0,4,0">
+                            <Grid Width="40" Margin="0,0,4,0">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="*" />
                                     <RowDefinition Height="*" />
@@ -615,7 +615,6 @@
                                 Grid.Column="2"
                                 Click="emoteButton_Click"
                                 Content="&#xED54;"
-                                FontSize="16"
                                 Style="{ThemeResource IconToggleButtonStyle}"
                                 Visibility="{Binding CanSend, Converter={StaticResource BoolVisibilityConverter}}">
                             </ToggleButton>

--- a/Unicord.Universal/Pages/ChannelPage.xaml.cs
+++ b/Unicord.Universal/Pages/ChannelPage.xaml.cs
@@ -1,12 +1,12 @@
-﻿using DSharpPlus.Entities;
-using Microsoft.Toolkit.Uwp.Helpers;
-using Microsoft.Toolkit.Uwp.UI.Controls;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using DSharpPlus.Entities;
+using Microsoft.Toolkit.Uwp.Helpers;
+using Microsoft.Toolkit.Uwp.UI.Controls;
 using Unicord.Universal.Commands;
 using Unicord.Universal.Controls;
 using Unicord.Universal.Integration;
@@ -170,6 +170,10 @@ namespace Unicord.Universal.Pages
             {
                 var scrollViewer = MessageList.FindChild<ScrollViewer>("ScrollViewer");
                 scrollViewer.ViewChanged += ScrollViewer_ViewChanged;
+                scrollViewer.ManipulationMode = ManipulationModes.System | ManipulationModes.TranslateX;
+
+                var swipeService = SwipeOpenService.GetForCurrentView();
+                swipeService.AddAdditionalElement(scrollViewer);
 
                 ShowSidebarButtonContainer.Visibility = this.FindParent<DiscordPage>() == null ? Visibility.Collapsed : Visibility.Visible;
 
@@ -236,7 +240,7 @@ namespace Unicord.Universal.Pages
 
                     NoMessages.Visibility = Visibility.Collapsed;
                 });
-                
+
                 if (ViewModel.Channel.Guild?.IsSynced == false && ViewModel.Channel.Guild.IsLarge)
                 {
                     await ViewModel.Channel.Guild.SyncAsync().ConfigureAwait(false);
@@ -787,6 +791,10 @@ namespace Unicord.Universal.Pages
 
         private void OpenPane(Type t = null, object parameter = null)
         {
+            var helper = SwipeOpenService.GetForCurrentView().Helper;
+            if (helper != null)
+                helper.IsEnabled = false;
+
             IsPaneOpen = true;
             SidebarGrid.Visibility = Visibility.Visible;
             if (Window.Current.Bounds.Width <= 1024)
@@ -802,6 +810,10 @@ namespace Unicord.Universal.Pages
 
         private void ClosePane()
         {
+            var helper = SwipeOpenService.GetForCurrentView().Helper;
+            if (helper != null)
+                helper.IsEnabled = true;
+
             IsPaneOpen = false;
             if (Window.Current.Bounds.Width > 1024)
             {
@@ -870,7 +882,7 @@ namespace Unicord.Universal.Pages
                 await WindowManager.OpenChannelWindowAsync(_viewModel.Channel);
 
                 var service = DiscordNavigationService.GetForCurrentView();
-                await service.NavigateAsync(null);
+                await service.NavigateAsync(null, true);
 
                 _viewModel.Dispose();
                 _channelHistory.Remove(_viewModel);
@@ -885,7 +897,7 @@ namespace Unicord.Universal.Pages
                 await WindowManager.OpenChannelWindowAsync(_viewModel.Channel, ApplicationViewMode.CompactOverlay);
 
                 var service = DiscordNavigationService.GetForCurrentView();
-                await service.NavigateAsync(null);
+                await service.NavigateAsync(null, true);
 
                 _viewModel.Dispose();
                 _channelHistory.Remove(_viewModel);

--- a/Unicord.Universal/Pages/ChannelPage.xaml.cs
+++ b/Unicord.Universal/Pages/ChannelPage.xaml.cs
@@ -208,7 +208,7 @@ namespace Unicord.Universal.Pages
             if (e.Handled)
                 return;
 
-            this.FindParent<MainPage>()?.LeaveFullscreen();
+            FullscreenService.GetForCurrentView()?.LeaveFullscreen();
             var last = _channelHistory.ElementAtOrDefault(_channelHistory.Count - 1);
             if (last != null)
             {

--- a/Unicord.Universal/Pages/ChannelPage.xaml.cs
+++ b/Unicord.Universal/Pages/ChannelPage.xaml.cs
@@ -859,7 +859,7 @@ namespace Unicord.Universal.Pages
 
         private void EditButton_Click(object sender, RoutedEventArgs e)
         {
-            this.FindParent<DiscordPage>().OpenCustomPane(typeof(ChannelEditPage), _viewModel.Channel);
+            //this.FindParent<DiscordPage>().OpenCustomPane(typeof(ChannelEditPage), _viewModel.Channel);
         }
 
         private async void NewWindowButton_Click(object sender, RoutedEventArgs e)

--- a/Unicord.Universal/Pages/ChannelPage.xaml.cs
+++ b/Unicord.Universal/Pages/ChannelPage.xaml.cs
@@ -78,17 +78,17 @@ namespace Unicord.Universal.Pages
                 }
 
                 this.AddAccelerator(VirtualKey.D, VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, EditMode_Invoked);
-                emoteButton.AddAccelerator(VirtualKey.E, VirtualKeyModifiers.Control);
-                pinsButton.AddAccelerator(VirtualKey.P, VirtualKeyModifiers.Control);
-                userListButton.AddAccelerator(VirtualKey.U, VirtualKeyModifiers.Control);
-                uploadButton.AddAccelerator(VirtualKey.U, VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift);
-                searchButton.AddAccelerator(VirtualKey.F, VirtualKeyModifiers.Control);
-                newWindowButton.AddAccelerator(VirtualKey.N, VirtualKeyModifiers.Control);
+                EmoteButton.AddAccelerator(VirtualKey.E, VirtualKeyModifiers.Control);
+                PinsButton.AddAccelerator(VirtualKey.P, VirtualKeyModifiers.Control);
+                UserListButton.AddAccelerator(VirtualKey.U, VirtualKeyModifiers.Control);
+                UploadButton.AddAccelerator(VirtualKey.U, VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift);
+                SearchButton.AddAccelerator(VirtualKey.F, VirtualKeyModifiers.Control);
+                NewWindowButton.AddAccelerator(VirtualKey.N, VirtualKeyModifiers.Control);
             }
 
-            uploadItems.IsEnabledChanged += UploadItems_IsEnabledChanged;
-            messageTextBox.KeyDown += messageTextBox_KeyDown;
-            messageList.AddHandler(TappedEvent, new TappedEventHandler(MessageList_Tapped), true);
+            UploadItems.IsEnabledChanged += UploadItems_IsEnabledChanged;
+            MessageTextBox.KeyDown += messageTextBox_KeyDown;
+            MessageList.AddHandler(TappedEvent, new TappedEventHandler(MessageList_Tapped), true);
         }
 
         private void OnSuspending(object sender, SuspendingEventArgs e)
@@ -136,14 +136,14 @@ namespace Unicord.Universal.Pages
                 }
 
                 var args = this.FindParent<MainPage>()?.Arguments;
-                WindowManager.HandleTitleBarForControl(topGrid);
+                WindowManager.HandleTitleBarForControl(TopGrid);
                 WindowManager.SetChannelForCurrentWindow(chan.Id);
 
                 ViewModel = model;
                 DataContext = ViewModel;
 
                 if (AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Desktop")
-                    messageTextBox.Focus(FocusState.Keyboard);
+                    MessageTextBox.Focus(FocusState.Keyboard);
 
                 while (_channelHistory.Count > 10)
                 {
@@ -168,10 +168,10 @@ namespace Unicord.Universal.Pages
         {
             if (!_scrollHandlerAdded)
             {
-                var scrollViewer = messageList.FindChild<ScrollViewer>("ScrollViewer");
+                var scrollViewer = MessageList.FindChild<ScrollViewer>("ScrollViewer");
                 scrollViewer.ViewChanged += ScrollViewer_ViewChanged;
 
-                showSidebarButtonContainer.Visibility = this.FindParent<DiscordPage>() == null ? Visibility.Collapsed : Visibility.Visible;
+                ShowSidebarButtonContainer.Visibility = this.FindParent<DiscordPage>() == null ? Visibility.Collapsed : Visibility.Visible;
 
                 _scrollHandlerAdded = true;
             }
@@ -231,10 +231,10 @@ namespace Unicord.Universal.Pages
             {
                 await Dispatcher.AwaitableRunAsync(() =>
                 {
-                    loadingProgress.Visibility = Visibility.Visible;
-                    loadingProgress.IsIndeterminate = true;
+                    LoadingProgress.Visibility = Visibility.Visible;
+                    LoadingProgress.IsIndeterminate = true;
 
-                    noMessages.Visibility = Visibility.Collapsed;
+                    NoMessages.Visibility = Visibility.Collapsed;
                 });
                 
                 if (ViewModel.Channel.Guild?.IsSynced == false && ViewModel.Channel.Guild.IsLarge)
@@ -252,14 +252,14 @@ namespace Unicord.Universal.Pages
 
             await Dispatcher.AwaitableRunAsync(() =>
             {
-                loadingProgress.Visibility = Visibility.Collapsed;
-                loadingProgress.IsIndeterminate = false;
+                LoadingProgress.Visibility = Visibility.Collapsed;
+                LoadingProgress.IsIndeterminate = false;
             }).ConfigureAwait(false);
 
             if (IsPaneOpen)
             {
                 await Dispatcher.AwaitableRunAsync(() =>
-                    sidebarFrame.Navigate(sidebarFrame.CurrentSourcePageType, ViewModel.Channel)).ConfigureAwait(false);
+                    SidebarFrame.Navigate(SidebarFrame.CurrentSourcePageType, ViewModel.Channel)).ConfigureAwait(false);
             }
 
             await JumpListManager.AddToListAsync(_viewModel.Channel);
@@ -272,7 +272,7 @@ namespace Unicord.Universal.Pages
             {
                 if (scroll.VerticalOffset >= (scroll.ScrollableHeight - scroll.ViewportHeight) && ViewModel.Channel.ReadState?.Unread != false)
                 {
-                    var message = messageList.Items.LastOrDefault() as DiscordMessage;
+                    var message = MessageList.Items.LastOrDefault() as DiscordMessage;
                     if (message != null)
                     {
                         await message.AcknowledgeAsync().ConfigureAwait(false);
@@ -312,10 +312,10 @@ namespace Unicord.Universal.Pages
                 var lastMessage = _viewModel.Messages.LastOrDefault(m => m.Author.IsCurrent);
                 if (lastMessage != null)
                 {
-                    var container = messageList.ContainerFromItem(lastMessage);
+                    var container = MessageList.ContainerFromItem(lastMessage);
                     if (container != null)
                     {
-                        messageList.ScrollIntoView(lastMessage, ScrollIntoViewAlignment.Leading);
+                        MessageList.ScrollIntoView(lastMessage, ScrollIntoViewAlignment.Leading);
                         var viewer = container.FindChild<MessageViewer>();
                         viewer.BeginEditing();
                     }
@@ -325,7 +325,7 @@ namespace Unicord.Universal.Pages
 
         private async void messageTextBox_TextChanged(object sender, TextChangedEventArgs e)
         {
-            await ViewModel.TriggerTypingAsync(messageTextBox.Text).ConfigureAwait(false);
+            await ViewModel.TriggerTypingAsync(MessageTextBox.Text).ConfigureAwait(false);
         }
 
         private async void messageTextBox_Paste(object sender, TextControlPasteEventArgs e)
@@ -339,7 +339,7 @@ namespace Unicord.Universal.Pages
                     var items = (await dataPackageView.GetStorageItemsAsync()).OfType<StorageFile>();
                     foreach (var item in items)
                     {
-                        await uploadItems.AddStorageFileAsync(item);
+                        await UploadItems.AddStorageFileAsync(item);
                     }
 
                     return;
@@ -349,7 +349,7 @@ namespace Unicord.Universal.Pages
                 {
                     e.Handled = true;
                     var file = await Tools.GetImageFileFromDataPackage(dataPackageView);
-                    await uploadItems.AddStorageFileAsync(file, true);
+                    await UploadItems.AddStorageFileAsync(file, true);
 
                     return;
                 }
@@ -366,13 +366,13 @@ namespace Unicord.Universal.Pages
 
         internal void FocusTextBox()
         {
-            messageTextBox.Focus(FocusState.Keyboard);
-            messageTextBox.SelectionStart = messageTextBox.Text.Length;
+            MessageTextBox.Focus(FocusState.Keyboard);
+            MessageTextBox.SelectionStart = MessageTextBox.Text.Length;
         }
 
         private async void sendButton_Click(object sender, RoutedEventArgs e)
         {
-            messageTextBox.Focus(FocusState.Keyboard);
+            MessageTextBox.Focus(FocusState.Keyboard);
             await SendAsync();
         }
 
@@ -382,27 +382,27 @@ namespace Unicord.Universal.Pages
             {
                 if (ViewModel.FileUploads.Any())
                 {
-                    uploadProgress.Visibility = Visibility.Visible;
+                    UploadProgress.Visibility = Visibility.Visible;
                     var progress = new Progress<double?>(d =>
                     {
-                        if (d == null && !uploadProgress.IsIndeterminate)
+                        if (d == null && !UploadProgress.IsIndeterminate)
                         {
-                            uploadProgress.IsIndeterminate = true;
+                            UploadProgress.IsIndeterminate = true;
                         }
                         else
                         {
-                            uploadProgress.Value = d.Value;
+                            UploadProgress.Value = d.Value;
                         }
                     });
 
-                    await ViewModel.SendMessageAsync(messageTextBox, progress).ConfigureAwait(false);
+                    await ViewModel.SendMessageAsync(MessageTextBox, progress).ConfigureAwait(false);
                 }
                 else
                 {
-                    await ViewModel.SendMessageAsync(messageTextBox).ConfigureAwait(false);
+                    await ViewModel.SendMessageAsync(MessageTextBox).ConfigureAwait(false);
                 }
 
-                await Dispatcher.AwaitableRunAsync(() => uploadProgress.Visibility = Visibility.Collapsed);
+                await Dispatcher.AwaitableRunAsync(() => UploadProgress.Visibility = Visibility.Collapsed);
             }
             catch (Exception ex)
             {
@@ -428,8 +428,8 @@ namespace Unicord.Universal.Pages
 
         private void BeginShowTitleBar()
         {
-            topGrid.Visibility = Visibility.Visible;
-            footerGrid.Visibility = Visibility.Visible;
+            TopGrid.Visibility = Visibility.Visible;
+            FooterGrid.Visibility = Visibility.Visible;
             _titleBarTimer?.Stop();
 
             HideTitleBar.Stop();
@@ -439,7 +439,7 @@ namespace Unicord.Universal.Pages
         private void BeginHideTitleBar()
         {
             ShowTitleBar.Stop();
-            HideTitleBarAnimation.To = -topGrid.RenderSize.Height;
+            HideTitleBarAnimation.To = -TopGrid.RenderSize.Height;
             HideTitleBar.Begin();
         }
 
@@ -447,36 +447,36 @@ namespace Unicord.Universal.Pages
         {
             if ((bool)e.NewValue == true)
             {
-                uploadItems.Visibility = Visibility.Visible;
-                hideUploadPanel.Stop();
-                showUploadPanel.Begin();
+                UploadItems.Visibility = Visibility.Visible;
+                HideUploadPanel.Stop();
+                ShowUploadPanel.Begin();
             }
             else
             {
-                showUploadPanel.Stop();
-                hideUploadPanel.Begin();
+                ShowUploadPanel.Stop();
+                HideUploadPanel.Begin();
             }
         }
 
         private void uploadButton_Click(object sender, RoutedEventArgs e)
         {
-            if (photoPicker.Visibility == Visibility.Visible)
+            if (PhotoPicker.Visibility == Visibility.Visible)
             {
-                hidePhotoPicker.Begin();
+                HidePhotoPicker.Begin();
             }
             else
             {
-                photoPicker.Visibility = Visibility.Visible;
-                showPhotoPicker.Begin();
+                PhotoPicker.Visibility = Visibility.Visible;
+                ShowPhotoPicker.Begin();
 
-                loadingImagesRing.IsActive = true;
+                LoadingImagesRing.IsActive = true;
 
                 try
                 {
                     var queryOption = new QueryOptions(CommonFileQuery.OrderByDate, new string[] { ".jpg", ".jpeg", ".png", ".mp4", ".mov", ".gif" }) { FolderDepth = FolderDepth.Deep };
                     var photosQuery = KnownFolders.PicturesLibrary.CreateFileQueryWithOptions(queryOption);
                     var factory = new FileInformationFactory(photosQuery, ThumbnailMode.SingleItem, 256);
-                    photosList.ItemsSource = factory.GetVirtualizedFilesVector();
+                    PhotosList.ItemsSource = factory.GetVirtualizedFilesVector();
                 }
                 catch (Exception ex)
                 {
@@ -484,7 +484,7 @@ namespace Unicord.Universal.Pages
                     // HockeyClient.Current.TrackException(ex, new Dictionary<string, string> { ["type"] = "FileQueryFailure" });
                 }
 
-                loadingImagesRing.IsActive = false;
+                LoadingImagesRing.IsActive = false;
             }
         }
 
@@ -498,18 +498,18 @@ namespace Unicord.Universal.Pages
                 var folder = App.RoamingSettings.Read("SavePhotos", true) ? KnownFolders.CameraRoll : ApplicationData.Current.TemporaryFolder;
                 await file.MoveAsync(folder, fileName, NameCollisionOption.GenerateUniqueName);
 
-                hidePhotoPicker.Begin();
-                await uploadItems.AddStorageFileAsync(file);
+                HidePhotoPicker.Begin();
+                await UploadItems.AddStorageFileAsync(file);
             }
         }
 
         private async void PhotosList_ItemClick(object sender, ItemClickEventArgs e)
         {
-            hidePhotoPicker.Begin();
+            HidePhotoPicker.Begin();
 
             if (e.ClickedItem is IStorageFile item)
             {
-                await uploadItems.AddStorageFileAsync(item);
+                await UploadItems.AddStorageFileAsync(item);
             }
         }
 
@@ -528,10 +528,10 @@ namespace Unicord.Universal.Pages
 
                 var files = await picker.PickMultipleFilesAsync();
 
-                hidePhotoPicker.Begin();
+                HidePhotoPicker.Begin();
                 foreach (var file in files)
                 {
-                    await uploadItems.AddStorageFileAsync(file);
+                    await UploadItems.AddStorageFileAsync(file);
                 }
             }
             catch { }
@@ -544,26 +544,26 @@ namespace Unicord.Universal.Pages
 
         private void HidePhotoPicker_Completed(object sender, object e)
         {
-            photosList.ItemsSource = null;
-            loadingImagesRing.IsActive = false;
-            photoPicker.Visibility = Visibility.Collapsed;
+            PhotosList.ItemsSource = null;
+            LoadingImagesRing.IsActive = false;
+            PhotoPicker.Visibility = Visibility.Collapsed;
         }
 
         private void ShowUploadPanel_Completed(object sender, object e)
         {
             // just to make sure
-            uploadItems.Visibility = Visibility.Visible;
+            UploadItems.Visibility = Visibility.Visible;
         }
 
         private void HideUploadPanel_Completed(object sender, object e)
         {
-            photoPicker.Visibility = Visibility.Collapsed;
-            uploadItems.Visibility = Visibility.Collapsed;
+            PhotoPicker.Visibility = Visibility.Collapsed;
+            UploadItems.Visibility = Visibility.Collapsed;
         }
 
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
-            hidePhotoPicker.Begin();
+            HidePhotoPicker.Begin();
         }
 
         private void RemoveItemButton_Click(object sender, RoutedEventArgs e)
@@ -584,7 +584,7 @@ namespace Unicord.Universal.Pages
             EnsureEmotePicker();
 
             var pane = InputPane.GetForCurrentView();
-            var flyout = FlyoutBase.GetAttachedFlyout(emoteButton);
+            var flyout = FlyoutBase.GetAttachedFlyout(EmoteButton);
 
             if (button.IsChecked == true)
             {
@@ -619,13 +619,13 @@ namespace Unicord.Universal.Pages
                 _emotePicker.EmojiPicked += EmotePicker_EmojiPicked;
             }
 
-            var flyout = (Flyout)FlyoutBase.GetAttachedFlyout(emoteButton);
+            var flyout = (Flyout)FlyoutBase.GetAttachedFlyout(EmoteButton);
 
             if (Window.Current.CoreWindow.Bounds.Width > 400)
             {
-                if (footerGrid.Children.Contains(_emotePicker))
+                if (FooterGrid.Children.Contains(_emotePicker))
                 {
-                    footerGrid.Children.Remove(_emotePicker);
+                    FooterGrid.Children.Remove(_emotePicker);
                 }
 
                 _emotePicker.Width = 300;
@@ -638,11 +638,11 @@ namespace Unicord.Universal.Pages
                     flyout = new Flyout { Content = _emotePicker };
                     flyout.Closed += (o, ev) =>
                     {
-                        emoteButton.IsChecked = false;
+                        EmoteButton.IsChecked = false;
                         _emotePicker.Unload();
                     };
 
-                    FlyoutBase.SetAttachedFlyout(emoteButton, flyout);
+                    FlyoutBase.SetAttachedFlyout(EmoteButton, flyout);
                 }
                 else if (flyout.Content != _emotePicker)
                 {
@@ -662,10 +662,10 @@ namespace Unicord.Universal.Pages
                 _emotePicker.Visibility = Visibility.Collapsed;
                 _emotePicker.Padding = new Thickness(10, 0, 10, 0);
 
-                if (!footerGrid.Children.Contains(_emotePicker))
+                if (!FooterGrid.Children.Contains(_emotePicker))
                 {
                     Grid.SetRow(_emotePicker, 4);
-                    footerGrid.Children.Add(_emotePicker);
+                    FooterGrid.Children.Add(_emotePicker);
                 }
             }
 
@@ -676,14 +676,14 @@ namespace Unicord.Universal.Pages
         {
             if (e != null)
             {
-                if (messageTextBox.Text.Length > 0 && !char.IsWhiteSpace(messageTextBox.Text[messageTextBox.Text.Length - 1]))
+                if (MessageTextBox.Text.Length > 0 && !char.IsWhiteSpace(MessageTextBox.Text[MessageTextBox.Text.Length - 1]))
                 {
-                    messageTextBox.Text += " ";
+                    MessageTextBox.Text += " ";
                 }
 
-                messageTextBox.Text += $"{e} ";
-                messageTextBox.Select(messageTextBox.Text.Length, 0);
-                messageTextBox.Focus(FocusState.Programmatic);
+                MessageTextBox.Text += $"{e} ";
+                MessageTextBox.Select(MessageTextBox.Text.Length, 0);
+                MessageTextBox.Focus(FocusState.Programmatic);
             }
         }
 
@@ -691,7 +691,7 @@ namespace Unicord.Universal.Pages
         {
             if (sender.FocusState != FocusState.Programmatic)
             {
-                emoteButton.IsChecked = false;
+                EmoteButton.IsChecked = false;
                 if (_emotePicker != null)
                 {
                     _emotePicker.Unload();
@@ -730,14 +730,14 @@ namespace Unicord.Universal.Pages
         {
             _viewModel.IsEditMode = true;
 
-            messageList.SelectionMode = ListViewSelectionMode.Multiple;
+            MessageList.SelectionMode = ListViewSelectionMode.Multiple;
 
             if (message != null)
             {
-                messageList.SelectedItems.Add(message);
+                MessageList.SelectedItems.Add(message);
             }
 
-            messageList.ItemTemplate = (DataTemplate)Resources["EditingMessageTemplate"];
+            MessageList.ItemTemplate = (DataTemplate)Resources["EditingMessageTemplate"];
             ShowEditControls.Begin();
         }
 
@@ -745,8 +745,8 @@ namespace Unicord.Universal.Pages
         {
             _viewModel.IsEditMode = false;
 
-            messageList.SelectionMode = ListViewSelectionMode.None;
-            messageList.ItemTemplate = (DataTemplate)Resources["DefaultMessageTemplate"];
+            MessageList.SelectionMode = ListViewSelectionMode.None;
+            MessageList.ItemTemplate = (DataTemplate)Resources["DefaultMessageTemplate"];
             HideEditControls.Begin();
         }
 
@@ -760,7 +760,7 @@ namespace Unicord.Universal.Pages
             var loader = ResourceLoader.GetForCurrentView("ChannelPage");
             if (await UIUtilities.ShowYesNoDialogAsync(loader.GetString("MassDeleteTitle"), loader.GetString("MassDeleteMessage"), "\xE74D"))
             {
-                var items = messageList.SelectedItems.OfType<DiscordMessage>().ToArray();
+                var items = MessageList.SelectedItems.OfType<DiscordMessage>().ToArray();
 
                 LeaveEditMode();
 
@@ -780,7 +780,7 @@ namespace Unicord.Universal.Pages
             {
                 if (!command.CanExecute(item))
                 {
-                    messageList.SelectedItems.Remove(item);
+                    MessageList.SelectedItems.Remove(item);
                 }
             }
         }
@@ -788,15 +788,15 @@ namespace Unicord.Universal.Pages
         private void OpenPane(Type t = null, object parameter = null)
         {
             IsPaneOpen = true;
-            sidebarGrid.Visibility = Visibility.Visible;
+            SidebarGrid.Visibility = Visibility.Visible;
             if (Window.Current.Bounds.Width <= 1024)
             {
                 OpenPaneStoryboard.Begin();
             }
 
-            if (t != null && sidebarFrame.CurrentSourcePageType != t)
+            if (t != null && SidebarFrame.CurrentSourcePageType != t)
             {
-                sidebarFrame.Navigate(t, parameter);
+                SidebarFrame.Navigate(t, parameter);
             }
         }
 
@@ -805,17 +805,17 @@ namespace Unicord.Universal.Pages
             IsPaneOpen = false;
             if (Window.Current.Bounds.Width > 1024)
             {
-                sidebarGrid.Visibility = Visibility.Collapsed;
+                SidebarGrid.Visibility = Visibility.Collapsed;
             }
 
             ClosePaneStoryboard.Begin();
 
-            sidebarFrame.Navigate(typeof(Page));
+            SidebarFrame.Navigate(typeof(Page));
         }
 
         public void TogglePane(Type t = null, object parameter = null)
         {
-            if (IsPaneOpen && sidebarFrame.CurrentSourcePageType == t)
+            if (IsPaneOpen && SidebarFrame.CurrentSourcePageType == t)
             {
                 ClosePane();
             }
@@ -827,7 +827,7 @@ namespace Unicord.Universal.Pages
 
         private void ClosePaneStoryboard_Completed(object sender, object e)
         {
-            sidebarGrid.Visibility = Visibility.Collapsed;
+            SidebarGrid.Visibility = Visibility.Collapsed;
         }
 
         private void MessageList_Tapped(object sender, TappedRoutedEventArgs e)
@@ -894,8 +894,8 @@ namespace Unicord.Universal.Pages
 
         private void HideTitleBar_Completed(object sender, object e)
         {
-            topGrid.Visibility = Visibility.Collapsed;
-            footerGrid.Visibility = Visibility.Collapsed;
+            TopGrid.Visibility = Visibility.Collapsed;
+            FooterGrid.Visibility = Visibility.Collapsed;
         }
     }
 }

--- a/Unicord.Universal/Pages/ChannelPage.xaml.cs
+++ b/Unicord.Universal/Pages/ChannelPage.xaml.cs
@@ -13,6 +13,7 @@ using Unicord.Universal.Integration;
 using Unicord.Universal.Models;
 using Unicord.Universal.Pages.Management;
 using Unicord.Universal.Pages.Subpages;
+using Unicord.Universal.Services;
 using Unicord.Universal.Utilities;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Core;
@@ -868,7 +869,9 @@ namespace Unicord.Universal.Pages
                 WindowManager.SetChannelForCurrentWindow(0);
                 await WindowManager.OpenChannelWindowAsync(_viewModel.Channel);
 
-                this.FindParent<DiscordPage>().Navigate(null, new DrillInNavigationTransitionInfo());
+                var service = DiscordNavigationService.GetForCurrentView();
+                await service.NavigateAsync(null);
+
                 _viewModel.Dispose();
                 _channelHistory.Remove(_viewModel);
             }
@@ -881,7 +884,9 @@ namespace Unicord.Universal.Pages
                 WindowManager.SetChannelForCurrentWindow(0);
                 await WindowManager.OpenChannelWindowAsync(_viewModel.Channel, ApplicationViewMode.CompactOverlay);
 
-                this.FindParent<DiscordPage>().Navigate(null, new DrillInNavigationTransitionInfo());
+                var service = DiscordNavigationService.GetForCurrentView();
+                await service.NavigateAsync(null);
+
                 _viewModel.Dispose();
                 _channelHistory.Remove(_viewModel);
             }

--- a/Unicord.Universal/Pages/DiscordPage.xaml
+++ b/Unicord.Universal/Pages/DiscordPage.xaml
@@ -21,7 +21,7 @@
         <ExponentialEase x:Key="EaseEnter" EasingMode="EaseOut" Exponent="7" />
         <ExponentialEase x:Key="EaseExit" EasingMode="EaseIn" Exponent="4.5" />
 
-        <Storyboard x:Key="OpenSettingsDesktopStoryboard" x:Name="OpenSettingsDesktopStoryboard" Completed="OpenSettingsStoryboard_Completed">
+        <Storyboard x:Key="OpenSettingsDesktopStoryboard" x:Name="OpenSettingsDesktopStoryboard">
             <DoubleAnimation
                 EasingFunction="{StaticResource EaseEnter}"
                 Storyboard.TargetName="SettingsPaneTransform"
@@ -139,141 +139,7 @@
                 To="0"
                 Duration="00:00:00.33" />
         </Storyboard>
-
-        <Storyboard x:Key="OpenCustomStoryboard" x:Name="OpenCustomStoryboard">
-            <DoubleAnimation
-                EasingFunction="{StaticResource EaseEnter}"
-                Storyboard.TargetName="CustomPaneTranslate"
-                Storyboard.TargetProperty="X"
-                To="0"
-                Duration="00:00:00.00" />
-            <DoubleAnimation
-                EasingFunction="{StaticResource EaseEnter}"
-                Storyboard.TargetName="MainGridTransform"
-                Storyboard.TargetProperty="X"
-                To="0"
-                Duration="00:00:00.00" />
-            <DoubleAnimation
-                EasingFunction="{StaticResource EaseEnter}"
-                Storyboard.TargetName="CustomPaneScale"
-                Storyboard.TargetProperty="ScaleX"
-                From="1.1"
-                To="1"
-                Duration="00:00:00.66" />
-            <DoubleAnimation
-                EasingFunction="{StaticResource EaseEnter}"
-                Storyboard.TargetName="CustomPaneScale"
-                Storyboard.TargetProperty="ScaleY"
-                From="1.1"
-                To="1"
-                Duration="00:00:00.66" />
-            <DoubleAnimation
-                EasingFunction="{StaticResource EaseEnter}"
-                Storyboard.TargetName="CustomOverlayGrid"
-                Storyboard.TargetProperty="Opacity"
-                To="1"
-                Duration="00:00:00.66" />
-        </Storyboard>
-        <Storyboard
-            x:Key="CloseCustomStoryboard"
-            x:Name="CloseCustomStoryboard"
-            Completed="CloseCustomMobileStoryboard_Completed">
-            <DoubleAnimation
-                EasingFunction="{StaticResource EaseExit}"
-                Storyboard.TargetName="CustomPaneTranslate"
-                Storyboard.TargetProperty="X"
-                To="0"
-                Duration="00:00:00.00" />
-            <DoubleAnimation
-                EasingFunction="{StaticResource EaseEnter}"
-                Storyboard.TargetName="MainGridTransform"
-                Storyboard.TargetProperty="X"
-                To="0"
-                Duration="00:00:00.00" />
-            <DoubleAnimation
-                EasingFunction="{StaticResource EaseExit}"
-                Storyboard.TargetName="CustomPaneScale"
-                Storyboard.TargetProperty="ScaleX"
-                To="1.1"
-                Duration="00:00:00.25" />
-            <DoubleAnimation
-                EasingFunction="{StaticResource EaseExit}"
-                Storyboard.TargetName="CustomPaneScale"
-                Storyboard.TargetProperty="ScaleY"
-                To="1.1"
-                Duration="00:00:00.25" />
-            <DoubleAnimation
-                EasingFunction="{StaticResource EaseExit}"
-                Storyboard.TargetName="CustomOverlayGrid"
-                Storyboard.TargetProperty="Opacity"
-                To="0"
-                Duration="00:00:00.25" />
-        </Storyboard>
-        <Storyboard x:Key="OpenCustomMobileStoryboard" x:Name="OpenCustomMobileStoryboard">
-            <DoubleAnimation
-                Storyboard.TargetName="CustomPaneScale"
-                Storyboard.TargetProperty="ScaleX"
-                To="1"
-                Duration="00:00:00" />
-            <DoubleAnimation
-                Storyboard.TargetName="CustomPaneScale"
-                Storyboard.TargetProperty="ScaleY"
-                To="1"
-                Duration="00:00:00" />
-            <DoubleAnimation
-                Storyboard.TargetName="CustomOverlayGrid"
-                Storyboard.TargetProperty="Opacity"
-                To="1"
-                Duration="00:00:00.00" />
-
-            <DoubleAnimation
-                x:Name="CustomOpenAnimation"
-                EasingFunction="{StaticResource EaseEnter}"
-                Storyboard.TargetName="CustomPaneTranslate"
-                Storyboard.TargetProperty="X"
-                To="0"
-                Duration="00:00:00.66" />
-            <DoubleAnimation
-                x:Name="CustomOpenAnimation2"
-                EasingFunction="{StaticResource EaseEnter}"
-                Storyboard.TargetName="MainGridTransform"
-                Storyboard.TargetProperty="X"
-                From="0"
-                Duration="00:00:00.66" />
-        </Storyboard>
-        <Storyboard
-            x:Key="CloseCustomMobileStoryboard"
-            x:Name="CloseCustomMobileStoryboard"
-            Completed="CloseCustomMobileStoryboard_Completed">
-            <DoubleAnimation
-                Storyboard.TargetName="CustomPaneScale"
-                Storyboard.TargetProperty="ScaleX"
-                To="1"
-                Duration="00:00:00" />
-            <DoubleAnimation
-                Storyboard.TargetName="CustomPaneScale"
-                Storyboard.TargetProperty="ScaleY"
-                To="1"
-                Duration="00:00:00" />
-            <DoubleAnimation
-                Storyboard.TargetName="CustomOverlayGrid"
-                Storyboard.TargetProperty="Opacity"
-                To="0"
-                Duration="00:00:00.00" />
-            <DoubleAnimation
-                x:Name="CustomCloseAnimation"
-                EasingFunction="{StaticResource EaseEnter}"
-                Storyboard.TargetName="CustomPaneTranslate"
-                Storyboard.TargetProperty="X"
-                From="0"
-                Duration="00:00:00.66" />
-            <DoubleAnimation
-                EasingFunction="{StaticResource EaseEnter}"
-                Storyboard.TargetName="MainGridTransform"
-                Storyboard.TargetProperty="X"
-                To="0"
-                Duration="00:00:00.66" />
-        </Storyboard>
+       
     </Page.Resources>
     <Grid>
         <Grid x:Name="grid">
@@ -324,7 +190,7 @@
                         DragItemsCompleted="guildsList_DragItemsCompleted"
                         ItemTemplate="{StaticResource GuildsListTemplate}"
                         ItemsSource="{Binding Guilds}"
-                        SelectedItem="{Binding SelectedGuild}"
+                        SelectedItem="{Binding SelectedGuild, Mode=TwoWay}"
                         ScrollViewer.VerticalScrollBarVisibility="Hidden"
                         SelectionChanged="GuildsList_SelectionChanged"
                         ShowsScrollingPlaceholders="False"
@@ -562,25 +428,6 @@
                         </controls1:InAppNotification.ContentTemplate>
                     </controls1:InAppNotification>
                 </Grid>
-            </Grid>
-        </Grid>
-
-        <Grid
-            x:Name="CustomOverlayGrid"
-            Opacity="0"
-            Visibility="Collapsed">
-            <Grid
-                x:Name="CustomContainer"
-                HorizontalAlignment="Stretch"
-                VerticalAlignment="Stretch"
-                Background="{ThemeResource MainBackgroundBrush}">
-                <Grid.RenderTransform>
-                    <TransformGroup>
-                        <ScaleTransform x:Name="CustomPaneScale" ScaleX="1" ScaleY="1" />
-                        <TranslateTransform x:Name="CustomPaneTranslate" X="0" Y="0" />
-                    </TransformGroup>
-                </Grid.RenderTransform>
-                <Frame x:Name="CustomGrid" />
             </Grid>
         </Grid>
 

--- a/Unicord.Universal/Pages/DiscordPage.xaml
+++ b/Unicord.Universal/Pages/DiscordPage.xaml
@@ -9,9 +9,11 @@
     xmlns:lib="using:Microsoft.UI.Xaml.Controls"
     xmlns:sub="using:Unicord.Universal.Pages.Subpages"
     xmlns:models="using:Unicord.Universal.Models"
+    NavigationCacheMode="Required"
     x:Name="self"
     Loaded="Page_Loaded"
     Unloaded="Page_Unloaded"
+    SizeChanged="Self_SizeChanged"
     mc:Ignorable="d">
     <Page.DataContext>
         <models:DiscordPageModel/>

--- a/Unicord.Universal/Pages/DiscordPage.xaml
+++ b/Unicord.Universal/Pages/DiscordPage.xaml
@@ -316,7 +316,6 @@
                     </Grid>
 
                     <ListView
-                        x:Name="guildsList"
                         Grid.Row="1"
                         AllowDrop="True"
                         CanDrag="True"
@@ -347,6 +346,7 @@
                                     x:Name="friendsItem"
                                     MinWidth="0"
                                     Padding="0"
+                                    IsSelected="{Binding IsFriendsSelected}"
                                     HorizontalContentAlignment="Stretch"
                                     Tapped="friendsItem_Tapped">
                                     <SymbolIcon
@@ -356,7 +356,6 @@
                                 </ListViewItem>
 
                                 <ListView
-                                    x:Name="unreadDms"
                                     ItemsSource="{Binding UnreadDMs}"
                                     SelectedItem="{Binding SelectedDM}"
                                     Visibility="{Binding UnreadDMs.Count, Converter={StaticResource BoolVisibilityConverter}}"

--- a/Unicord.Universal/Pages/DiscordPage.xaml
+++ b/Unicord.Universal/Pages/DiscordPage.xaml
@@ -324,7 +324,8 @@
                         CanReorderItems="True"
                         DragItemsCompleted="guildsList_DragItemsCompleted"
                         ItemTemplate="{StaticResource GuildsListTemplate}"
-                        ItemsSource="{x:Bind _guilds}"
+                        ItemsSource="{Binding Guilds}"
+                        SelectedItem="{Binding SelectedGuild}"
                         ScrollViewer.VerticalScrollBarVisibility="Hidden"
                         SelectionChanged="GuildsList_SelectionChanged"
                         ShowsScrollingPlaceholders="False"
@@ -356,6 +357,9 @@
 
                                 <ListView
                                     x:Name="unreadDms"
+                                    ItemsSource="{Binding UnreadDMs}"
+                                    SelectedItem="{Binding SelectedDM}"
+                                    Visibility="{Binding UnreadDMs.Count, Converter={StaticResource BoolVisibilityConverter}}"
                                     ScrollViewer.VerticalScrollMode="Disabled"
                                     SelectionChanged="UnreadDms_SelectionChanged">
                                     <ListView.HeaderTemplate>

--- a/Unicord.Universal/Pages/DiscordPage.xaml.cs
+++ b/Unicord.Universal/Pages/DiscordPage.xaml.cs
@@ -46,7 +46,7 @@ namespace Unicord.Universal.Pages
         internal DiscordPageModel Model { get; }
 
         private bool _visibility;
-        private SwipeOpenHelper _helper;
+        internal SwipeOpenHelper helper;
 
         private bool _isPaneOpen => ContentTransform.X != 0;
 
@@ -56,7 +56,7 @@ namespace Unicord.Universal.Pages
             Model = DataContext as DiscordPageModel;
 
             _visibility = Window.Current.Visible;
-            _helper = new SwipeOpenHelper(content, this, OpenPaneMobileStoryboard, ClosePaneMobileStoryboard);
+            helper = new SwipeOpenHelper(content, this, OpenPaneMobileStoryboard, ClosePaneMobileStoryboard);
 
             Window.Current.VisibilityChanged += Current_VisibilityChanged;
         }
@@ -203,6 +203,7 @@ namespace Unicord.Universal.Pages
         {
             if (ActualWidth <= 768)
             {
+                helper.Cancel();
                 OpenPaneMobileStoryboard.Begin();
             }
         }
@@ -211,6 +212,7 @@ namespace Unicord.Universal.Pages
         {
             if (ActualWidth <= 768 || ContentTransform.X < 0)
             {
+                helper.Cancel();
                 ClosePaneMobileStoryboard.Begin();
             }
         }
@@ -281,19 +283,10 @@ namespace Unicord.Universal.Pages
             }
         }
 
-        private void friendsItem_Tapped(object sender, TappedRoutedEventArgs e)
+        private async void friendsItem_Tapped(object sender, TappedRoutedEventArgs e)
         {
-            Model.IsFriendsSelected = true;
-            Model.SelectedGuild = null;
-            if (!(sidebarFrame.Content is DMChannelsPage))
-            {
-                sidebarFrame.Navigate(typeof(DMChannelsPage), null, new DrillInNavigationTransitionInfo());
-            }
-
-            if (!(mainFrame.Content is FriendsPage) || (mainFrame.Content is ChannelPage cp && cp.ViewModel?.Channel.IsPrivate == true))
-            {
-                mainFrame.Navigate(typeof(FriendsPage), null, new SlideNavigationTransitionInfo());
-            }
+            var service = DiscordNavigationService.GetForCurrentView();
+            await service.NavigateAsync(null);
         }
 
         private async void guildsList_DragItemsCompleted(ListViewBase sender, DragItemsCompletedEventArgs args)
@@ -393,7 +386,7 @@ namespace Unicord.Universal.Pages
 
         private void Self_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            _helper.IsEnabled = e.NewSize.Width <= 768;
+            helper.IsEnabled = e.NewSize.Width <= 768;
         }
     }
 }

--- a/Unicord.Universal/Pages/DiscordPage.xaml.cs
+++ b/Unicord.Universal/Pages/DiscordPage.xaml.cs
@@ -371,51 +371,6 @@ namespace Unicord.Universal.Pages
             CloseSplitPane();
         }
 
-        public void OpenCustomPane(Type pageType, object parameter)
-        {
-            CustomOverlayGrid.Visibility = Visibility.Visible;
-
-            if (ActualWidth > 768)
-            {
-                CustomContainer.RenderTransformOrigin = new Point(0.5, 0.5);
-                OpenCustomStoryboard.Begin();
-            }
-            else
-            {
-                CustomContainer.RenderTransformOrigin = new Point(0, 0);
-                CustomOpenAnimation.From = ActualWidth;
-                CustomOpenAnimation2.To = -ActualWidth;
-                OpenCustomMobileStoryboard.Begin();
-            }
-
-            CustomGrid.Navigate(pageType, parameter, new SuppressNavigationTransitionInfo());
-        }
-
-        public void CloseCustomPane()
-        {
-            if (ActualWidth > 768)
-            {
-                CustomContainer.RenderTransformOrigin = new Point(0.5, 0.5);
-                CloseCustomStoryboard.Begin();
-            }
-            else
-            {
-                CustomContainer.RenderTransformOrigin = new Point(0, 0);
-                CustomCloseAnimation.To = ActualWidth;
-                CloseCustomMobileStoryboard.Begin();
-            }
-        }
-
-        private void CloseCustomMobileStoryboard_Completed(object sender, object e)
-        {
-            CustomOverlayGrid.Visibility = Visibility.Collapsed;
-        }
-
-        private void OpenSettingsStoryboard_Completed(object sender, object e)
-        {
-
-        }
-
         private void CreateServerItem_Tapped(object sender, TappedRoutedEventArgs e)
         {
             var element = sender as FrameworkElement;

--- a/Unicord.Universal/Pages/DiscordPage.xaml.cs
+++ b/Unicord.Universal/Pages/DiscordPage.xaml.cs
@@ -22,6 +22,7 @@ using Windows.Foundation;
 using Windows.Foundation.Metadata;
 using Windows.UI;
 using Windows.UI.Core;
+using Windows.UI.Input;
 using Windows.UI.Notifications;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
@@ -45,16 +46,17 @@ namespace Unicord.Universal.Pages
         internal DiscordPageModel Model { get; }
 
         private bool _visibility;
+        private SwipeOpenHelper _helper;
 
         private bool _isPaneOpen => ContentTransform.X != 0;
 
         public DiscordPage()
         {
             InitializeComponent();
-            NavigationCacheMode = NavigationCacheMode.Required;
             Model = DataContext as DiscordPageModel;
 
             _visibility = Window.Current.Visible;
+            _helper = new SwipeOpenHelper(content, this, OpenPaneMobileStoryboard, ClosePaneMobileStoryboard);
 
             Window.Current.VisibilityChanged += Current_VisibilityChanged;
         }
@@ -387,6 +389,11 @@ namespace Unicord.Universal.Pages
         private void FindServerIcon_Tapped(object sender, TappedRoutedEventArgs e)
         {
 
+        }
+
+        private void Self_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            _helper.IsEnabled = e.NewSize.Width <= 768;
         }
     }
 }

--- a/Unicord.Universal/Pages/DiscordPage.xaml.cs
+++ b/Unicord.Universal/Pages/DiscordPage.xaml.cs
@@ -14,6 +14,7 @@ using Unicord.Universal.Integration;
 using Unicord.Universal.Models;
 using Unicord.Universal.Pages.Settings;
 using Unicord.Universal.Pages.Subpages;
+using Unicord.Universal.Services;
 using Unicord.Universal.Utilities;
 using Unicord.Universal.Voice;
 using Windows.ApplicationModel.Resources;
@@ -35,9 +36,9 @@ namespace Unicord.Universal.Pages
 {
     public sealed partial class DiscordPage : Page
     {
-        public new Frame Frame => mainFrame;
-        private ObservableCollection<DiscordGuild> _guilds = new ObservableCollection<DiscordGuild>();
-        private ObservableCollection<DiscordDmChannel> _unreadDms = new ObservableCollection<DiscordDmChannel>();
+        public Frame MainFrame => mainFrame;
+        public Frame SidebarFrame => sidebarFrame;
+
         private MainPageArgs _args;
         private bool _loaded;
         private bool _visibility;
@@ -71,7 +72,8 @@ namespace Unicord.Universal.Pages
                 if (_loaded)
                 {
                     var channel = await App.Discord.GetChannelAsync(_args.ChannelId);
-                    Navigate(channel, new DrillInNavigationTransitionInfo());
+                    var service = DiscordNavigationService.GetForCurrentView();
+                    await service.NavigateAsync(channel);
                 }
             }
         }
@@ -97,59 +99,26 @@ namespace Unicord.Universal.Pages
                 navigation.BackRequested += Navigation_BackRequested;
 
                 App.Discord.MessageCreated += Notification_MessageCreated;
-                App.Discord.UserSettingsUpdated += Discord_UserSettingsUpdated;
-                App.Discord.GuildCreated += Discord_GuildCreated;
-                App.Discord.GuildDeleted += Discord_GuildDeleted;
-                App.Discord.DmChannelCreated += Discord_DmChannelCreated;
-                App.Discord.DmChannelDeleted += Discord_DmChannelDeleted;
-
+                
                 UpdateTitleBar();
                 CheckSettingsPane();
 
                 _loaded = true;
 
-                var guildPositions = App.Discord.UserSettings?.GuildPositions;
-                foreach (var guild in App.Discord.Guilds.Values.OrderBy(g => guildPositions?.IndexOf(g.Id) ?? 0))
-                {
-                    _guilds.Add(guild);
-                }
-
-                _unreadDms.CollectionChanged += (o, ev) =>
-                {
-                    if (_unreadDms.Count > 0)
-                    {
-                        unreadDms.Visibility = Visibility.Visible;
-                    }
-                    else
-                    {
-                        unreadDms.Visibility = Visibility.Collapsed;
-                    }
-                };
-
-                foreach (var dm in App.Discord.PrivateChannels.Values)
-                {
-                    if (dm.ReadState.MentionCount > 0)
-                    {
-                        _unreadDms.Add(dm);
-                    }
-
-                    dm.PropertyChanged += Dm_PropertyChanged;
-                }
-
-                unreadDms.ItemsSource = _unreadDms;
-                unreadDms.Visibility = _unreadDms.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
-
                 this.FindParent<MainPage>().HideConnectingOverlay();
+
+                var service = DiscordNavigationService.GetForCurrentView();
 
                 if (_args != null)
                 {
                     var channel = await App.Discord.GetChannelAsync(_args.ChannelId);
-                    Navigate(channel);
+                    await service.NavigateAsync(channel);
                 }
                 else
                 {
                     friendsItem.IsSelected = true;
-                    friendsItem_Tapped(null, null);
+                    SidebarFrame.Navigate(typeof(DMChannelsPage));
+                    MainFrame.Navigate(typeof(FriendsPage));
                 }
 
                 var possibleConnection = await VoiceConnectionModel.FindExistingConnectionAsync();
@@ -179,16 +148,6 @@ namespace Unicord.Universal.Pages
             if (App.Discord != null)
             {
                 App.Discord.MessageCreated -= Notification_MessageCreated;
-                App.Discord.UserSettingsUpdated -= Discord_UserSettingsUpdated;
-                App.Discord.GuildCreated -= Discord_GuildCreated;
-                App.Discord.GuildDeleted -= Discord_GuildDeleted;
-                App.Discord.DmChannelCreated -= Discord_DmChannelCreated;
-                App.Discord.DmChannelDeleted -= Discord_DmChannelDeleted;
-
-                foreach (var dm in App.Discord?.PrivateChannels.Values)
-                {
-                    dm.PropertyChanged -= Dm_PropertyChanged;
-                }
             }
         }
 
@@ -203,68 +162,7 @@ namespace Unicord.Universal.Pages
                 e.Handled = true;
             }
         }
-
-        private async Task Discord_DmChannelCreated(DmChannelCreateEventArgs e)
-        {
-            await Dispatcher.RunIdleAsync(d => e.Channel.PropertyChanged += Dm_PropertyChanged);
-        }
-
-        private async Task Discord_DmChannelDeleted(DmChannelDeleteEventArgs e)
-        {
-            await Dispatcher.RunIdleAsync(d => e.Channel.PropertyChanged -= Dm_PropertyChanged);
-        }
-
-        private async Task Discord_GuildCreated(GuildCreateEventArgs e)
-        {
-            if (!_guilds.Contains(e.Guild))
-            {
-                await Dispatcher.RunIdleAsync(d => _guilds.Add(e.Guild));
-            }
-        }
-
-        private async Task Discord_GuildDeleted(GuildDeleteEventArgs e)
-        {
-            await Dispatcher.RunIdleAsync(d => _guilds.Remove(e.Guild));
-        }
-
-        private void Dm_PropertyChanged(object sender, PropertyChangedEventArgs e)
-        {
-            var d = sender as DiscordDmChannel;
-            if (e.PropertyName == nameof(d.ReadState))
-            {
-                if (d.ReadState.MentionCount > 0)
-                {
-                    if (!_unreadDms.Contains(d))
-                    {
-                        _unreadDms.Add(d);
-                    }
-                }
-                else
-                {
-                    _unreadDms.Remove(d);
-                }
-            }
-        }
-
-        private async Task Discord_UserSettingsUpdated(UserSettingsUpdateEventArgs e)
-        {
-            var guildPositions = App.Discord.UserSettings?.GuildPositions;
-            if (!_guilds.Select(g => g.Id).SequenceEqual(guildPositions))
-            {
-                for (var i = 0; i < guildPositions.Count; i++)
-                {
-                    var id = guildPositions[i];
-                    var guild = _guilds[i];
-                    if (id != guild.Id)
-                    {
-                        await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-                        {
-                            _guilds.Move(_guilds.IndexOf(_guilds.First(g => g.Id == id)), i);
-                        });
-                    }
-                }
-            }
-        }
+        
 
         private async Task Notification_MessageCreated(MessageCreateEventArgs e)
         {
@@ -319,7 +217,7 @@ namespace Unicord.Universal.Pages
 
         private void ShowNotification(DiscordMessage message)
         {
-            if (Frame.CurrentSourcePageType == typeof(ChannelPage))
+            if (MainFrame.CurrentSourcePageType == typeof(ChannelPage))
             {
                 notification.Margin = new Thickness(0, 42, 4, 0);
             }
@@ -332,17 +230,21 @@ namespace Unicord.Universal.Pages
             notification.Show(7_000);
         }
 
-        private void Notification_Tapped(object sender, TappedRoutedEventArgs e)
+        private async  void Notification_Tapped(object sender, TappedRoutedEventArgs e)
         {
             var message = ((sender as InAppNotification).Content as MessageViewer)?.Message;
             if (message != null)
             {
-                Navigate(message.Channel, new DrillInNavigationTransitionInfo());
+                var service = DiscordNavigationService.GetForCurrentView();
+                await service.NavigateAsync(message.Channel);
             }
         }
 
         private async void GuildsList_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if ((DataContext as DiscordPageModel).Navigating)
+                return;
+
             if (e.AddedItems.FirstOrDefault() is DiscordGuild g)
             {
                 if (!g.IsUnavailable)
@@ -359,98 +261,14 @@ namespace Unicord.Universal.Pages
             }
         }
 
-        private void UnreadDms_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        private async void UnreadDms_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if ((DataContext as DiscordPageModel).Navigating)
+                return;
+
             if (e.AddedItems.FirstOrDefault() is DiscordDmChannel c)
             {
-                Navigate(c);
-            }
-        }
-
-        internal async void Navigate(DiscordChannel channel, NavigationTransitionInfo info = null)
-        {
-            try
-            {
-                CloseSplitPane();
-
-                unreadDms.SelectionChanged -= UnreadDms_SelectionChanged;
-                guildsList.SelectionChanged -= GuildsList_SelectionChanged;
-
-                guildsList.SelectedIndex = -1;
-                unreadDms.SelectedIndex = -1;
-                friendsItem.IsSelected = false;
-
-                if (channel == null)
-                {
-                    friendsItem.IsSelected = true;
-                    sidebarFrame.Navigate(typeof(DMChannelsPage), channel, new DrillInNavigationTransitionInfo());
-                    Frame.Navigate(typeof(FriendsPage));
-
-                    return;
-                }
-
-                if (await WindowManager.ActivateOtherWindow(channel))
-                    return;
-
-                if (channel is DiscordDmChannel dm)
-                {
-                    unreadDms.SelectedItem = dm;
-                    friendsItem.IsSelected = true;
-
-                    if (!(sidebarFrame.Content is DMChannelsPage))
-                        sidebarFrame.Navigate(typeof(DMChannelsPage), channel, new DrillInNavigationTransitionInfo());
-                }
-                else if (channel.Guild != null)
-                {
-                    guildsList.SelectedIndex = _guilds.IndexOf(channel.Guild);
-
-                    if (!(sidebarFrame.Content is GuildChannelListPage p) || p.Guild != channel.Guild)
-                        sidebarFrame.Navigate(typeof(GuildChannelListPage), channel.Guild, new DrillInNavigationTransitionInfo());
-                }
-
-                if (channel.Type == ChannelType.Voice)
-                {
-                    try
-                    {
-                        var voice = new VoiceConnectionModel(channel);
-                        (DataContext as DiscordPageModel).VoiceModel = voice;
-                        await voice.ConnectAsync();
-                    }
-                    catch (Exception ex)
-                    {
-                        await UIUtilities.ShowErrorDialogAsync("Failed to connect to voice!", ex.Message);
-                    }
-
-                    return;
-                }
-
-                if (!(Frame.Content is ChannelPage cPage) || cPage.ViewModel?.Channel?.Id != channel.Id)
-                {
-                    if (channel.IsNSFW)
-                    {
-                        var loader = ResourceLoader.GetForViewIndependentUse();
-                        if (await WindowsHelloManager.VerifyAsync(Constants.VERIFY_NSFW, loader.GetString("VerifyNSFWDisplayReason")))
-                        {
-                            if (!App.RoamingSettings.Read($"NSFW_{channel.Id}", false) || !App.RoamingSettings.Read($"NSFW_All", false))
-                            {
-                                Frame.Navigate(typeof(ChannelWarningPage), channel, info ?? new SlideNavigationTransitionInfo());
-                            }
-                            else
-                            {
-                                Frame.Navigate(typeof(ChannelPage), channel, info ?? new SlideNavigationTransitionInfo());
-                            }
-                        }
-                    }
-                    else
-                    {
-                        Frame.Navigate(typeof(ChannelPage), channel, info ?? new SlideNavigationTransitionInfo());
-                    }
-                }
-            }
-            finally
-            {
-                unreadDms.SelectionChanged += UnreadDms_SelectionChanged;
-                guildsList.SelectionChanged += GuildsList_SelectionChanged;
+                await DiscordNavigationService.GetForCurrentView().NavigateAsync(c);
             }
         }
 
@@ -485,7 +303,7 @@ namespace Unicord.Universal.Pages
 
         private async void guildsList_DragItemsCompleted(ListViewBase sender, DragItemsCompletedEventArgs args)
         {
-            var enumerable = _guilds.Select(g => g.Id);
+            var enumerable = (DataContext as DiscordPageModel).Guilds.Select(g => g.Id);
             if (!enumerable.SequenceEqual(App.Discord.UserSettings.GuildPositions))
             {
                 await App.Discord.UpdateUserSettingsAsync(enumerable.ToArray());

--- a/Unicord.Universal/Pages/Management/Channel/ChannelEditOverviewPage.xaml
+++ b/Unicord.Universal/Pages/Management/Channel/ChannelEditOverviewPage.xaml
@@ -1,0 +1,58 @@
+﻿<Page
+    x:Class="Unicord.Universal.Pages.Management.Channel.ChannelEditOverviewPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Unicord.Universal.Pages.Management.Channel"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+        <StackPanel x:Name="mainGrid" HorizontalAlignment="Stretch" Margin="12,0">
+            <TextBlock>Name</TextBlock>
+            <TextBox TextChanging="TextBox_TextChanging" Margin="0,4,0,12" PlaceholderText="something-witty" Text="{Binding Name, Mode=TwoWay}"/>
+
+            <StackPanel Visibility="{Binding IsText, Converter={StaticResource BoolVisibilityConverter}}">
+                <TextBlock>Topic</TextBlock>
+                <TextBox Padding="8,6" Margin="0,4,0,12" AcceptsReturn="True" MinHeight="100" IsSpellCheckEnabled="True" MaxLength="1024" PlaceholderText="What's this channel for?" Text="{Binding Topic, Mode=TwoWay}"/>
+
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel>
+                        <TextBlock Text="NSFW Channel" VerticalAlignment="Center"/>
+                        <TextBlock Style="{ThemeResource CaptionTextBlockStyle}">People will need to confirm they're over 18 before viewing this channel, and the server wide content filter won't apply here.</TextBlock>
+                    </StackPanel>
+                    <ToggleSwitch Grid.Column="1" Margin="12,0,0,0" Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding NSFW, Mode=TwoWay}" />
+                </Grid>
+            </StackPanel>
+
+            <StackPanel Visibility="{Binding IsVoice, Converter={StaticResource BoolVisibilityConverter}}">
+                <Grid Margin="0,4">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock>Bitrate</TextBlock>
+                    <Slider x:Name="BitrateSlider" Grid.Row="1" Value="{Binding Bitrate, Mode=TwoWay}" Minimum="8" Maximum="96" StepFrequency="4" Width="{Binding ActualWidth, ElementName=StarColumn}" />
+                    <TextBlock Grid.Column="1" Grid.Row="1" Margin="8,0,0,0" VerticalAlignment="Center" Width="{Binding ActualWidth, ElementName=AutoColumn}">
+                            <Run Text="{Binding Value, ElementName=BitrateSlider}"/>kbps
+                    </TextBlock>
+                    <TextBlock Grid.Row="2" Margin="0,4,0,0">User limit</TextBlock>
+                    <Slider x:Name="UserlimitSlider" Grid.Row="3" Value="{Binding Userlimit, Mode=TwoWay}" Minimum="0" Maximum="99" Width="{Binding ActualWidth, ElementName=StarColumn}" />
+                    <TextBlock Grid.Column="1" Grid.Row="3" Margin="8,0,0,0" VerticalAlignment="Center" Width="{Binding ActualWidth, ElementName=AutoColumn}">
+                            <Run Text="{Binding Value, ElementName=UserlimitSlider}"/> Users
+                    </TextBlock>
+                </Grid>
+            </StackPanel>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/Unicord.Universal/Pages/Management/Channel/ChannelEditOverviewPage.xaml.cs
+++ b/Unicord.Universal/Pages/Management/Channel/ChannelEditOverviewPage.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Unicord.Universal.Pages.Management.Channel
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class ChannelEditOverviewPage : Page
+    {
+        public ChannelEditOverviewPage()
+        {
+            this.InitializeComponent();
+        }
+
+        private void TextBox_TextChanging(TextBox sender, TextBoxTextChangingEventArgs args)
+        {
+            sender.Text = sender.Text.Replace(' ', '-').ToLowerInvariant();
+            sender.Select(sender.Text.Length, 0);
+        }
+    }
+}

--- a/Unicord.Universal/Pages/Management/Channel/ChannelEditPermissionsPage.xaml
+++ b/Unicord.Universal/Pages/Management/Channel/ChannelEditPermissionsPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page
+    x:Class="Unicord.Universal.Pages.Management.Channel.ChannelEditPermissionsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Unicord.Universal.Pages.Management.Channel"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+
+    </Grid>
+</Page>

--- a/Unicord.Universal/Pages/Management/Channel/ChannelEditPermissionsPage.xaml.cs
+++ b/Unicord.Universal/Pages/Management/Channel/ChannelEditPermissionsPage.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Unicord.Universal.Pages.Management.Channel
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class ChannelEditPermissionsPage : Page
+    {
+        public ChannelEditPermissionsPage()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/Unicord.Universal/Pages/Management/ChannelEditPage.xaml
+++ b/Unicord.Universal/Pages/Management/ChannelEditPage.xaml
@@ -7,105 +7,162 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:lib="using:Microsoft.UI.Xaml.Controls"
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:media="using:Microsoft.UI.Xaml.Media"
+    xmlns:pages="using:Unicord.Universal.Pages.Management.Channel"
     MaxWidth="1024" MaxHeight="768"
     mc:Ignorable="d" Loaded="Page_Loaded">
+    <Page.Resources>
+        <Style x:Key="CustomPaneToggleButtonStyle" BasedOn="{StaticResource IconButtonStyle}" TargetType="Button">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="FontFamily" Value="Segoe MDL2 Assets"/>
+            <Setter Property="FontSize" Value="16"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="UseLayoutRounding" Value="True"/>
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="HorizontalAlignment" Value="Left" />
+            <Setter Property="VerticalAlignment" Value="Top" />
+            <Setter Property="MinHeight" Value="{StaticResource PaneToggleButtonHeight}" />
+            <Setter Property="MinWidth" Value="{StaticResource PaneToggleButtonWidth}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Grid x:Name="LayoutRoot"
+                        MinWidth="{TemplateBinding MinWidth}"
+                        Height="{TemplateBinding MinHeight}"
+                        Margin="{TemplateBinding Padding}"
+                        Background="{TemplateBinding Background}"
+                              HorizontalAlignment="Stretch">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="40" />
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+
+                            <VisualStateManager.VisualStateGroups>
+                                <VisualStateGroup x:Name="CommonStates">
+                                    <VisualState x:Name="Normal">
+                                        <Storyboard>
+                                            <PointerUpThemeAnimation Storyboard.TargetName="LayoutRoot"/>
+                                        </Storyboard>
+                                    </VisualState>
+                                    <VisualState x:Name="PointerOver">
+                                        <VisualState.Setters>
+                                            <Setter Target="LayoutRoot.(media:RevealBrush.State)" Value="PointerOver"/>
+                                            <Setter Target="RevealBorder.Background" Value="{ThemeResource ButtonRevealBackgroundPointerOver}"/>
+                                            <Setter Target="RevealBorder.BorderBrush" Value="{ThemeResource ButtonRevealBorderBrushPointerOver}"/>
+                                            <Setter Target="Icon.Foreground" Value="{ThemeResource ButtonForegroundPointerOver}"/>
+                                        </VisualState.Setters>
+                                        <Storyboard>
+                                            <PointerUpThemeAnimation Storyboard.TargetName="LayoutRoot"/>
+                                        </Storyboard>
+                                    </VisualState>
+                                    <VisualState x:Name="Pressed">
+                                        <VisualState.Setters>
+                                            <Setter Target="LayoutRoot.(media:RevealBrush.State)" Value="Pressed"/>
+                                            <Setter Target="RevealBorder.Background" Value="{ThemeResource ButtonRevealBackgroundPressed}"/>
+                                            <Setter Target="RevealBorder.BorderBrush" Value="{ThemeResource ButtonRevealBorderBrushPressed}"/>
+                                            <Setter Target="Icon.Foreground" Value="{ThemeResource ButtonForegroundPressed}"/>
+                                        </VisualState.Setters>
+                                        <Storyboard>
+                                            <PointerDownThemeAnimation Storyboard.TargetName="LayoutRoot"/>
+                                        </Storyboard>
+                                    </VisualState>
+                                    <VisualState x:Name="Disabled">
+                                        <VisualState.Setters>
+                                            <Setter Target="RevealBorder.BorderBrush" Value="{ThemeResource ButtonRevealBorderBrushDisabled}"/>
+                                            <Setter Target="Icon.Foreground" Value="{ThemeResource ButtonForegroundDisabled}"/>
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                </VisualStateGroup>
+                            </VisualStateManager.VisualStateGroups>
+
+                            <TextBlock
+                                x:Name="Icon"
+                                Text="&#xE700;"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                FontSize="{TemplateBinding FontSize}"
+                                AutomationProperties.AccessibilityView="Raw"/>
+
+                            <ContentPresenter
+                            x:Name="ContentPresenter"
+                            VerticalContentAlignment="Center"
+                            Content="{TemplateBinding Content}"
+                            FontSize="{TemplateBinding FontSize}"
+                            Grid.Column="1"
+                            AutomationProperties.AccessibilityView="Raw"/>
+
+                            <Border
+                            x:Name="RevealBorder"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Grid.ColumnSpan="2"/>
+
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Page.Resources>
+    
     <controls:DropShadowPanel Style="{ThemeResource DropShadowPanelStyle}" Color="{ThemeResource SystemChromeBlackMediumColor}">
         <Grid x:Name="MainGrid" Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
 
-            <Grid x:Name="topGrid" Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}">
+            <Grid x:Name="topGrid" VerticalAlignment="Top" Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="42"/>
                     <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="42"/>
+                    <ColumnDefinition Width="40"/>
                 </Grid.ColumnDefinitions>
-                <Button x:Name="backButton" Style="{ThemeResource IconButtonStyle}" Click="BackButton_Click">&#xE72B;</Button>
-                <TextBlock x:Uid="/VideoEditor/VideoEditorHeader" Grid.Column="1" Style="{ThemeResource BaseTextBlockStyle}" Text="Editing Channel" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                <Button x:Name="acceptButton" Grid.Column="2" Style="{ThemeResource IconButtonStyle}" Click="AcceptButton_Click">&#xE8FB;</Button>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="40"/>
+                </Grid.RowDefinitions>
+                <Button x:Name="acceptButton" Grid.Column="2" Style="{ThemeResource StretchyIconButtonStyle}" Width="40" Height="40" Click="AcceptButton_Click">&#xE8FB;</Button>
                 <ProgressRing x:Name="progressRing" Grid.Column="2" Margin="2"/>
             </Grid>
 
             <lib:NavigationView x:Name="navigationView"
-                            Grid.Row="1"
-                            IsBackButtonVisible="Collapsed"
-                            IsSettingsVisible="False"
-                            PaneDisplayMode="Auto"
-                            OpenPaneLength="250"
-                            BackRequested="NavigationView_BackRequested"
-                            Header="{Binding SelectedItem.Content, ElementName=navigationView}">
+                                IsBackEnabled="True"
+                                IsBackButtonVisible="Visible"
+                                IsSettingsVisible="False"
+                                PaneDisplayMode="Auto"
+                                OpenPaneLength="250"
+                                BackRequested="NavigationView_BackRequested"
+                                ItemInvoked="NavigationView_ItemInvoked"
+                                IsTitleBarAutoPaddingEnabled="False"
+                                PaneToggleButtonStyle="{StaticResource CustomPaneToggleButtonStyle}"
+                                Header="{Binding SelectedItem.Content, ElementName=navigationView}">
+                <lib:NavigationView.Resources>
+                    <Style x:Key="NavigationBackButtonNormalStyle" BasedOn="{StaticResource PaneToggleButtonStyle}" TargetType="Button">
+                        <Setter Property="Content" Value="&#xE72B;"/>
+                    </Style>
+                    <Style x:Key="NavigationBackButtonSmallStyle" BasedOn="{StaticResource PaneToggleButtonStyle}" TargetType="Button">
+                        <Setter Property="Content" Value="&#xE72B;"/>
+                    </Style>
+                </lib:NavigationView.Resources>
                 <lib:NavigationView.MenuItems>
-                    <lib:NavigationViewItem Content="Overview">
+                    <lib:NavigationViewItem Content="Overview" Tag="Overview" IsSelected="True">
                         <lib:NavigationViewItem.Icon>
                             <FontIcon Glyph="&#xE179;" />
                         </lib:NavigationViewItem.Icon>
                     </lib:NavigationViewItem>
-                    <lib:NavigationViewItem Content="Permissions">
+                    <lib:NavigationViewItem Content="Permissions" Tag="Permissions">
                         <lib:NavigationViewItem.Icon>
                             <FontIcon Glyph="&#xE192;" />
                         </lib:NavigationViewItem.Icon>
                     </lib:NavigationViewItem>
-                    <lib:NavigationViewItem Content="Invites">
+                    <lib:NavigationViewItem Content="Invites" Tag="Invites">
                         <lib:NavigationViewItem.Icon>
                             <FontIcon Glyph="&#xE71B;" />
                         </lib:NavigationViewItem.Icon>
                     </lib:NavigationViewItem>
-                    <lib:NavigationViewItem Content="Webhooks">
+                    <lib:NavigationViewItem Content="Webhooks" Tag="Webhooks">
                         <lib:NavigationViewItem.Icon>
                             <FontIcon Glyph="&#xE12B;" />
                         </lib:NavigationViewItem.Icon>
                     </lib:NavigationViewItem>
                 </lib:NavigationView.MenuItems>
 
-                <ContentControl x:Name="mainContent" IsEnabled="True" Margin="0,12" HorizontalContentAlignment="Stretch" Grid.Row="1">
-                    <StackPanel x:Name="mainGrid" HorizontalAlignment="Stretch" Margin="12,0">
-                        <TextBlock>Name</TextBlock>
-                        <TextBox TextChanging="TextBox_TextChanging" Margin="0,4,0,12" PlaceholderText="something-witty" Text="{Binding Name, Mode=TwoWay}"/>
-
-                        <StackPanel Visibility="{Binding IsText, Converter={StaticResource BoolVisibilityConverter}}">
-                            <TextBlock>Topic</TextBlock>
-                            <TextBox Padding="8,6" Margin="0,4,0,12" AcceptsReturn="True" MinHeight="100" IsSpellCheckEnabled="True" MaxLength="1024" PlaceholderText="What's this channel for?" Text="{Binding Topic, Mode=TwoWay}"/>
-
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-                                <StackPanel>
-                                    <TextBlock Text="NSFW Channel" VerticalAlignment="Center"/>
-                                    <TextBlock Style="{ThemeResource CaptionTextBlockStyle}">People will need to confirm they're over 18 before viewing this channel, and the server wide content filter won't apply here.</TextBlock>
-                                </StackPanel>
-                                <ToggleSwitch Grid.Column="1" Margin="12,0,0,0" Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding NSFW, Mode=TwoWay}" />
-                            </Grid>
-                        </StackPanel>
-
-                        <StackPanel Visibility="{Binding IsVoice, Converter={StaticResource BoolVisibilityConverter}}">
-                            <Grid Margin="0,4">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                </Grid.RowDefinitions>
-                                <TextBlock>Bitrate</TextBlock>
-                                <Slider x:Name="BitrateSlider" Grid.Row="1" Value="{Binding Bitrate, Mode=TwoWay}" Minimum="8" Maximum="96" StepFrequency="4" Width="{Binding ActualWidth, ElementName=StarColumn}" />
-                                <TextBlock Grid.Column="1" Grid.Row="1" Margin="8,0,0,0" VerticalAlignment="Center" Width="{Binding ActualWidth, ElementName=AutoColumn}">
-                            <Run Text="{Binding Value, ElementName=BitrateSlider}"/>kbps
-                                </TextBlock>
-                                <TextBlock Grid.Row="2" Margin="0,4,0,0">User limit</TextBlock>
-                                <Slider x:Name="UserlimitSlider" Grid.Row="3" Value="{Binding Userlimit, Mode=TwoWay}" Minimum="0" Maximum="99" Width="{Binding ActualWidth, ElementName=StarColumn}" />
-                                <TextBlock Grid.Column="1" Grid.Row="3" Margin="8,0,0,0" VerticalAlignment="Center" Width="{Binding ActualWidth, ElementName=AutoColumn}">
-                            <Run Text="{Binding Value, ElementName=UserlimitSlider}"/> Users
-                                </TextBlock>
-                            </Grid>
-                        </StackPanel>
-                    </StackPanel>
+                <ContentControl x:Name="mainContent" IsEnabled="True" Margin="0,8,0,12" HorizontalContentAlignment="Stretch" Grid.Row="1">
+                    <Frame x:Name="MainFrame" SourcePageType="pages:ChannelEditOverviewPage"/>
                 </ContentControl>
             </lib:NavigationView>
         </Grid>

--- a/Unicord.Universal/Pages/Management/ChannelEditPage.xaml
+++ b/Unicord.Universal/Pages/Management/ChannelEditPage.xaml
@@ -6,85 +6,108 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:lib="using:Microsoft.UI.Xaml.Controls"
-    mc:Ignorable="d" Loaded="Page_Loaded"
-    Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
-    <lib:NavigationView x:Name="navigationView"
-                        IsBackEnabled="True"
-                        IsSettingsVisible="False"
-                        PaneDisplayMode="Auto"
-                        OpenPaneLength="250"
-                        BackRequested="NavigationView_BackRequested"
-                        Header="{Binding SelectedItem.Content, ElementName=navigationView}">
-        <lib:NavigationView.MenuItems>
-            <lib:NavigationViewItem Content="Overview">
-                <lib:NavigationViewItem.Icon>
-                    <FontIcon Glyph="&#xE179;" />
-                </lib:NavigationViewItem.Icon>
-            </lib:NavigationViewItem>
-            <lib:NavigationViewItem Content="Permissions">
-                <lib:NavigationViewItem.Icon>
-                    <FontIcon Glyph="&#xE192;" />
-                </lib:NavigationViewItem.Icon>
-            </lib:NavigationViewItem>
-            <lib:NavigationViewItem Content="Invites">
-                <lib:NavigationViewItem.Icon>
-                    <FontIcon Glyph="&#xE71B;" />
-                </lib:NavigationViewItem.Icon>
-            </lib:NavigationViewItem>
-            <lib:NavigationViewItem Content="Webhooks">
-                <lib:NavigationViewItem.Icon>
-                    <FontIcon Glyph="&#xE12B;" />
-                </lib:NavigationViewItem.Icon>
-            </lib:NavigationViewItem>
-        </lib:NavigationView.MenuItems>
+    xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    MaxWidth="1024" MaxHeight="768"
+    mc:Ignorable="d" Loaded="Page_Loaded">
+    <controls:DropShadowPanel Style="{ThemeResource DropShadowPanelStyle}" Color="{ThemeResource SystemChromeBlackMediumColor}">
+        <Grid x:Name="MainGrid" Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
 
-        <ContentControl x:Name="mainContent" IsEnabled="True" HorizontalContentAlignment="Stretch" Grid.Row="1">
-            <StackPanel x:Name="mainGrid" HorizontalAlignment="Stretch" Margin="12,0">
-                <TextBlock>Name</TextBlock>
-                <TextBox TextChanging="TextBox_TextChanging" Margin="0,4,0,12" PlaceholderText="something-witty" Text="{Binding Name, Mode=TwoWay}"/>
+            <Grid x:Name="topGrid" Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="42"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="42"/>
+                </Grid.ColumnDefinitions>
+                <Button x:Name="backButton" Style="{ThemeResource IconButtonStyle}" Click="BackButton_Click">&#xE72B;</Button>
+                <TextBlock x:Uid="/VideoEditor/VideoEditorHeader" Grid.Column="1" Style="{ThemeResource BaseTextBlockStyle}" Text="Editing Channel" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                <Button x:Name="acceptButton" Grid.Column="2" Style="{ThemeResource IconButtonStyle}" Click="AcceptButton_Click">&#xE8FB;</Button>
+                <ProgressRing x:Name="progressRing" Grid.Column="2" Margin="2"/>
+            </Grid>
 
-                <StackPanel Visibility="{Binding IsText, Converter={StaticResource BoolVisibilityConverter}}">
-                    <TextBlock>Topic</TextBlock>
-                    <TextBox Padding="8,6" Margin="0,4,0,12" AcceptsReturn="True" MinHeight="100" IsSpellCheckEnabled="True" MaxLength="1024" PlaceholderText="What's this channel for?" Text="{Binding Topic, Mode=TwoWay}"/>
+            <lib:NavigationView x:Name="navigationView"
+                            Grid.Row="1"
+                            IsBackButtonVisible="Collapsed"
+                            IsSettingsVisible="False"
+                            PaneDisplayMode="Auto"
+                            OpenPaneLength="250"
+                            BackRequested="NavigationView_BackRequested"
+                            Header="{Binding SelectedItem.Content, ElementName=navigationView}">
+                <lib:NavigationView.MenuItems>
+                    <lib:NavigationViewItem Content="Overview">
+                        <lib:NavigationViewItem.Icon>
+                            <FontIcon Glyph="&#xE179;" />
+                        </lib:NavigationViewItem.Icon>
+                    </lib:NavigationViewItem>
+                    <lib:NavigationViewItem Content="Permissions">
+                        <lib:NavigationViewItem.Icon>
+                            <FontIcon Glyph="&#xE192;" />
+                        </lib:NavigationViewItem.Icon>
+                    </lib:NavigationViewItem>
+                    <lib:NavigationViewItem Content="Invites">
+                        <lib:NavigationViewItem.Icon>
+                            <FontIcon Glyph="&#xE71B;" />
+                        </lib:NavigationViewItem.Icon>
+                    </lib:NavigationViewItem>
+                    <lib:NavigationViewItem Content="Webhooks">
+                        <lib:NavigationViewItem.Icon>
+                            <FontIcon Glyph="&#xE12B;" />
+                        </lib:NavigationViewItem.Icon>
+                    </lib:NavigationViewItem>
+                </lib:NavigationView.MenuItems>
 
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <StackPanel>
-                            <TextBlock Text="NSFW Channel" VerticalAlignment="Center"/>
-                            <TextBlock Style="{ThemeResource CaptionTextBlockStyle}">People will need to confirm they're over 18 before viewing this channel, and the server wide content filter won't apply here.</TextBlock>
+                <ContentControl x:Name="mainContent" IsEnabled="True" Margin="0,12" HorizontalContentAlignment="Stretch" Grid.Row="1">
+                    <StackPanel x:Name="mainGrid" HorizontalAlignment="Stretch" Margin="12,0">
+                        <TextBlock>Name</TextBlock>
+                        <TextBox TextChanging="TextBox_TextChanging" Margin="0,4,0,12" PlaceholderText="something-witty" Text="{Binding Name, Mode=TwoWay}"/>
+
+                        <StackPanel Visibility="{Binding IsText, Converter={StaticResource BoolVisibilityConverter}}">
+                            <TextBlock>Topic</TextBlock>
+                            <TextBox Padding="8,6" Margin="0,4,0,12" AcceptsReturn="True" MinHeight="100" IsSpellCheckEnabled="True" MaxLength="1024" PlaceholderText="What's this channel for?" Text="{Binding Topic, Mode=TwoWay}"/>
+
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel>
+                                    <TextBlock Text="NSFW Channel" VerticalAlignment="Center"/>
+                                    <TextBlock Style="{ThemeResource CaptionTextBlockStyle}">People will need to confirm they're over 18 before viewing this channel, and the server wide content filter won't apply here.</TextBlock>
+                                </StackPanel>
+                                <ToggleSwitch Grid.Column="1" Margin="12,0,0,0" Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding NSFW, Mode=TwoWay}" />
+                            </Grid>
                         </StackPanel>
-                        <ToggleSwitch Grid.Column="1" Margin="12,0,0,0" Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding NSFW, Mode=TwoWay}" />
-                    </Grid>
-                </StackPanel>
 
-                <StackPanel Visibility="{Binding IsVoice, Converter={StaticResource BoolVisibilityConverter}}">
-                    <Grid Margin="0,4">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
-                        <TextBlock>Bitrate</TextBlock>
-                        <Slider x:Name="BitrateSlider" Grid.Row="1" Value="{Binding Bitrate, Mode=TwoWay}" Minimum="8" Maximum="96" StepFrequency="4" Width="{Binding ActualWidth, ElementName=StarColumn}" />
-                        <TextBlock Grid.Column="1" Grid.Row="1" Margin="8,0,0,0" VerticalAlignment="Center" Width="{Binding ActualWidth, ElementName=AutoColumn}">
+                        <StackPanel Visibility="{Binding IsVoice, Converter={StaticResource BoolVisibilityConverter}}">
+                            <Grid Margin="0,4">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <TextBlock>Bitrate</TextBlock>
+                                <Slider x:Name="BitrateSlider" Grid.Row="1" Value="{Binding Bitrate, Mode=TwoWay}" Minimum="8" Maximum="96" StepFrequency="4" Width="{Binding ActualWidth, ElementName=StarColumn}" />
+                                <TextBlock Grid.Column="1" Grid.Row="1" Margin="8,0,0,0" VerticalAlignment="Center" Width="{Binding ActualWidth, ElementName=AutoColumn}">
                             <Run Text="{Binding Value, ElementName=BitrateSlider}"/>kbps
-                        </TextBlock>
-                        <TextBlock Grid.Row="2" Margin="0,4,0,0">User limit</TextBlock>
-                        <Slider x:Name="UserlimitSlider" Grid.Row="3" Value="{Binding Userlimit, Mode=TwoWay}" Minimum="0" Maximum="99" Width="{Binding ActualWidth, ElementName=StarColumn}" />
-                        <TextBlock Grid.Column="1" Grid.Row="3" Margin="8,0,0,0" VerticalAlignment="Center" Width="{Binding ActualWidth, ElementName=AutoColumn}">
+                                </TextBlock>
+                                <TextBlock Grid.Row="2" Margin="0,4,0,0">User limit</TextBlock>
+                                <Slider x:Name="UserlimitSlider" Grid.Row="3" Value="{Binding Userlimit, Mode=TwoWay}" Minimum="0" Maximum="99" Width="{Binding ActualWidth, ElementName=StarColumn}" />
+                                <TextBlock Grid.Column="1" Grid.Row="3" Margin="8,0,0,0" VerticalAlignment="Center" Width="{Binding ActualWidth, ElementName=AutoColumn}">
                             <Run Text="{Binding Value, ElementName=UserlimitSlider}"/> Users
-                        </TextBlock>
-                    </Grid>
-                </StackPanel>
-            </StackPanel>
-        </ContentControl>
-    </lib:NavigationView>
+                                </TextBlock>
+                            </Grid>
+                        </StackPanel>
+                    </StackPanel>
+                </ContentControl>
+            </lib:NavigationView>
+        </Grid>
+    </controls:DropShadowPanel>
 </Page>

--- a/Unicord.Universal/Pages/Management/ChannelEditPage.xaml.cs
+++ b/Unicord.Universal/Pages/Management/ChannelEditPage.xaml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using DSharpPlus.Entities;
 using Unicord.Universal.Models;
+using Unicord.Universal.Services;
 using Unicord.Universal.Utilities;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
@@ -20,7 +21,7 @@ using NavigationViewBackRequestedEventArgs = Microsoft.UI.Xaml.Controls.Navigati
 
 namespace Unicord.Universal.Pages.Management
 {
-    public sealed partial class ChannelEditPage : Page
+    public sealed partial class ChannelEditPage : Page, IOverlay
     {
         private ChannelEditViewModel _viewModel;
 
@@ -42,25 +43,25 @@ namespace Unicord.Universal.Pages.Management
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             
-            WindowManager.HandleTitleBarForControl(navigationView, true);
+            WindowManager.HandleTitleBarForControl(topGrid);
         }
 
         private async void AcceptButton_Click(object sender, RoutedEventArgs e)
         {
-            //acceptButton.Visibility = Visibility.Collapsed;
+            acceptButton.Visibility = Visibility.Collapsed;
             mainContent.IsEnabled = false;
-            //backButton.IsEnabled = false;
-            //progressRing.IsActive = true;
+            backButton.IsEnabled = false;
+            progressRing.IsActive = true;
 
             await _viewModel.SaveChangesAsync();
 
-            //progressRing.IsActive = false;
-            this.FindParent<DiscordPage>().CloseCustomPane();
+            progressRing.IsActive = false;
+            OverlayService.GetForCurrentView().CloseOverlay();
         }
 
         private void BackButton_Click(object sender, RoutedEventArgs e)
         {
-            this.FindParent<DiscordPage>().CloseCustomPane();
+            OverlayService.GetForCurrentView().CloseOverlay();
         }
 
         private void TextBox_TextChanging(TextBox sender, TextBoxTextChangingEventArgs args)
@@ -79,7 +80,7 @@ namespace Unicord.Universal.Pages.Management
                 await _viewModel.SaveChangesAsync();
             }
 
-            this.FindParent<DiscordPage>().CloseCustomPane();
+            OverlayService.GetForCurrentView().CloseOverlay();
         }
     }
 }

--- a/Unicord.Universal/Pages/Subpages/DMChannelsPage.xaml.cs
+++ b/Unicord.Universal/Pages/Subpages/DMChannelsPage.xaml.cs
@@ -10,6 +10,7 @@ using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using Microsoft.Toolkit.Uwp.UI;
 using Unicord.Universal.Models;
+using Unicord.Universal.Services;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.UI.Core;
@@ -52,7 +53,7 @@ namespace Unicord.Universal.Pages.Subpages
             dmsList.SelectedIndex = -1;
         }
 
-        private void dmsList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        private async void dmsList_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             var dataContext = DataContext as DMChannelsViewModel;
             if (dataContext.UpdatingIndex)
@@ -61,7 +62,8 @@ namespace Unicord.Universal.Pages.Subpages
             var channel = e.AddedItems.FirstOrDefault() as DiscordChannel;
             if (channel != null)
             {
-                this.FindParent<DiscordPage>()?.Navigate(channel, null);
+                var service = DiscordNavigationService.GetForCurrentView();
+                await service.NavigateAsync(channel);
             }
         }
     }

--- a/Unicord.Universal/Pages/Subpages/DMChannelsPage.xaml.cs
+++ b/Unicord.Universal/Pages/Subpages/DMChannelsPage.xaml.cs
@@ -26,31 +26,33 @@ namespace Unicord.Universal.Pages.Subpages
 {
     public sealed partial class DMChannelsPage : Page
     {
-        private DiscordDmChannel _currentChannel;
+        private DMChannelsViewModel _model;
 
         public DMChannelsPage()
         {
             InitializeComponent();
+            _model = DataContext as DMChannelsViewModel;
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
+            _model.UpdatingIndex = true;
+
             if (e.Parameter is DiscordDmChannel channel)
             {
-                _currentChannel = channel;
-                dmsList.SelectedItem = channel;
+                _model.SelectedIndex = _model.DMChannels.IndexOf(channel);
             }
             else
             {
-                _currentChannel = null;
-                dmsList.SelectedIndex = -1;
+                _model.SelectedIndex = -1;
             }
+
+            _model.UpdatingIndex = false;
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
-            _currentChannel = null;
-            dmsList.SelectedIndex = -1;
+            _model.SelectedIndex = -1;
         }
 
         private async void dmsList_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/Unicord.Universal/Pages/Subpages/FriendsPage.xaml
+++ b/Unicord.Universal/Pages/Subpages/FriendsPage.xaml
@@ -46,14 +46,14 @@
                         <Ellipse.Fill>
                             <ImageBrush>
                                 <ImageBrush.ImageSource>
-                                    <BitmapImage UriSource="{x:Bind User.NonAnimatedAvatarUrl}" DecodePixelType="Logical" DecodePixelWidth="64" DecodePixelHeight="64"/>
+                                    <BitmapImage UriSource="{Binding User.NonAnimatedAvatarUrl}" DecodePixelType="Logical" DecodePixelWidth="64" DecodePixelHeight="64"/>
                                 </ImageBrush.ImageSource>
                             </ImageBrush>
                         </Ellipse.Fill>
                     </Ellipse>
                     <Ellipse Width="20" Height="20" Canvas.Left="44" Canvas.Top="44" StrokeThickness="2" Stroke="#FF171717">
                         <Ellipse.Fill>
-                            <SolidColorBrush Color="{x:Bind User.Presence, Converter={StaticResource PresenceColourConverter}}"/>
+                            <SolidColorBrush Color="{Binding User.Presence, Converter={StaticResource PresenceColourConverter}}"/>
                         </Ellipse.Fill>
                     </Ellipse>
                 </Canvas>
@@ -63,19 +63,19 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
-                        <TextBlock Name="text" Text="{x:Bind User.Username}" FontWeight="Bold"/>
-                        <TextBlock Grid.Row="1" FontSize="12" x:Name="presenceActivity" x:Load="{x:Bind User.Presence.Activity.Name, Converter={StaticResource BoolConverter}, FallbackValue=False}">
-                            <Run Text="{x:Bind User.Presence, Converter={StaticResource PresenceTextConverter}}"/> 
+                        <TextBlock Name="text" Text="{Binding User.Username}" FontWeight="Bold"/>
+                        <TextBlock Grid.Row="1" FontSize="12" x:Name="presenceActivity" Visibility="{Binding User.Presence.Activity.Name, Converter={StaticResource BoolVisibilityConverter}, FallbackValue=Collapsed}">
+                            <Run Text="{Binding User.Presence, Converter={StaticResource PresenceTextConverter}}"/>
                         </TextBlock>
                     </Grid>
-                    <StackPanel x:Name="overlayContent" x:Phase="10" DataContext="{x:Bind}" Orientation="Horizontal" Opacity="0" VerticalAlignment="Center" HorizontalAlignment="Right">
+                    <StackPanel x:Name="overlayContent" DataContext="{Binding}" Orientation="Horizontal" Opacity="0" VerticalAlignment="Center" HorizontalAlignment="Right">
                         <Button Style="{ThemeResource IconButtonStyle}" BorderThickness="0" Margin="4,0">
                             <SymbolIcon Symbol="VideoChat"/>
                         </Button>
                         <Button Style="{ThemeResource IconButtonStyle}" BorderThickness="0" Margin="4,0">
                             <SymbolIcon Symbol="Phone"/>
                         </Button>
-                        <Button Style="{ThemeResource IconButtonStyle}" Command="{StaticResource MessageUserCommand}" CommandParameter="{x:Bind User}" BorderThickness="0" Margin="4,0">
+                        <Button Style="{ThemeResource IconButtonStyle}" Command="{StaticResource MessageUserCommand}" CommandParameter="{Binding User}" BorderThickness="0" Margin="4,0">
                             <SymbolIcon Symbol="Message"/>
                         </Button>
                     </StackPanel>
@@ -83,31 +83,8 @@
             </Grid>
         </DataTemplate>
     </Page.Resources>
-    
+
     <controls:DropShadowPanel Style="{ThemeResource DropShadowPanelStyle}">
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup>
-                <VisualState x:Name="WideState">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="769" />
-                    </VisualState.StateTriggers>
-
-                    <VisualState.Setters>
-                        <Setter Target="showSidebarButton.Visibility" Value="Collapsed" />
-                    </VisualState.Setters>
-                </VisualState>
-
-                <VisualState x:Name="NarrowState">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="0" />
-                    </VisualState.StateTriggers>
-
-                    <VisualState.Setters>
-                        <Setter Target="showSidebarButton.Visibility" Value="Visible" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
 
         <Grid Background="{ThemeResource MainBackgroundBrush}">
             <Grid.RowDefinitions>
@@ -180,6 +157,29 @@
                     </PivotItem>
                 </Pivot.Items>
             </Pivot>
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup>
+                    <VisualState x:Name="WideState">
+                        <VisualState.StateTriggers>
+                            <AdaptiveTrigger MinWindowWidth="769" />
+                        </VisualState.StateTriggers>
+
+                        <VisualState.Setters>
+                            <Setter Target="showSidebarButton.Visibility" Value="Collapsed" />
+                        </VisualState.Setters>
+                    </VisualState>
+
+                    <VisualState x:Name="NarrowState">
+                        <VisualState.StateTriggers>
+                            <AdaptiveTrigger MinWindowWidth="0" />
+                        </VisualState.StateTriggers>
+
+                        <VisualState.Setters>
+                            <Setter Target="showSidebarButton.Visibility" Value="Visible" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
         </Grid>
     </controls:DropShadowPanel>
 </Page>

--- a/Unicord.Universal/Pages/Subpages/GuildChannelListPage.xaml.cs
+++ b/Unicord.Universal/Pages/Subpages/GuildChannelListPage.xaml.cs
@@ -8,6 +8,7 @@ using DSharpPlus;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using Unicord.Universal.Models;
+using Unicord.Universal.Services;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.UI.Core;
@@ -43,12 +44,13 @@ namespace Unicord.Universal.Pages.Subpages
             DataContext = new GuildChannelListViewModel(Guild);
         }
 
-        private void channelsList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        private async void channelsList_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             var channel = e.AddedItems.FirstOrDefault() as DiscordChannel;
             if (channel != null)
             {
-                this.FindParent<DiscordPage>().Navigate(channel, null);
+                var service = DiscordNavigationService.GetForCurrentView();
+                await service.NavigateAsync(channel);
             }
         }
     }

--- a/Unicord.Universal/Pages/VideoEditor.xaml
+++ b/Unicord.Universal/Pages/VideoEditor.xaml
@@ -8,7 +8,7 @@
     xmlns:controls="using:Unicord.Universal.Controls"
     xmlns:controls1="using:Microsoft.Toolkit.Uwp.UI.Controls"
     mc:Ignorable="d" Loaded="Page_Loaded" SizeChanged="Page_SizeChanged"
-    Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
+    MaxWidth="1600" MaxHeight="900">
 
     <Page.Resources>
         <ExponentialEase x:Key="Enter" Exponent="7" EasingMode="EaseOut" />
@@ -60,79 +60,81 @@
         </Storyboard>
     </Page.Resources>
 
-    <Grid>
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-            <Grid x:Name="topGrid" Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="42"/>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="42"/>
-                </Grid.ColumnDefinitions>
-                <Button x:Name="backButton" Style="{ThemeResource IconButtonStyle}" Click="BackButton_Click">&#xE72B;</Button>
-                <TextBlock x:Uid="/VideoEditor/VideoEditorHeader" Grid.Column="1" Style="{ThemeResource BaseTextBlockStyle}" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                <Button x:Name="acceptButton" Grid.Column="2" Style="{ThemeResource IconButtonStyle}" Click="AcceptButton_Click">&#xE8FB;</Button>
-            </Grid>
-            <Grid Grid.Row="1" Margin="0">
-                <MediaPlayerElement x:Name="mediaElement" Stretch="Uniform"></MediaPlayerElement>
-                <Grid x:Name="selectorGrid" Background="{ThemeResource SidebarSecondaryAcrylicElementBrush}" VerticalAlignment="Bottom" Grid.Row="2" Padding="8">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="auto"/>
-                            <ColumnDefinition Width="auto"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="auto"/>
-                            <ColumnDefinition Width="auto"/>
-                        </Grid.ColumnDefinitions>
-                        <Button x:Name="playPauseButton" Click="PlayPauseButton_Click"  Style="{ThemeResource IconButtonStyle}" Content="&#xE768;" Margin="0,0,8,0"/>
-                        <TextBlock x:Name="startPointText" Text="00:00" VerticalAlignment="Center" Grid.Column="1" />
-                        <controls:RangeSelector VerticalAlignment="Center" x:Name="rangeSelector" Value="0.5" Grid.Column="2" StepFrequency="0.1" ValueChanged="RangeSelector_ValueChanged" RangeChanged="RangeSelector_RangeChanged" Grid.Row="2" Margin="8,0" />
-                        <TextBlock x:Name="endPointText" Text="00:00" Grid.Column="3" VerticalAlignment="Center"/>
+    <controls1:DropShadowPanel Style="{ThemeResource DropShadowPanelStyle}">
+        <Grid Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <Grid x:Name="topGrid" Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="42"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="42"/>
+                    </Grid.ColumnDefinitions>
+                    <Button x:Name="backButton" Style="{ThemeResource IconButtonStyle}" Click="BackButton_Click">&#xE72B;</Button>
+                    <TextBlock x:Uid="/VideoEditor/VideoEditorHeader" Grid.Column="1" Style="{ThemeResource BaseTextBlockStyle}" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                    <Button x:Name="acceptButton" Grid.Column="2" Style="{ThemeResource IconButtonStyle}" Click="AcceptButton_Click">&#xE8FB;</Button>
+                </Grid>
+                <Grid Grid.Row="1" Margin="0">
+                    <MediaPlayerElement x:Name="mediaElement" Stretch="Uniform"></MediaPlayerElement>
+                    <Grid x:Name="selectorGrid" Background="{ThemeResource SidebarSecondaryAcrylicElementBrush}" VerticalAlignment="Bottom" Grid.Row="2" Padding="8">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto"/>
+                                <ColumnDefinition Width="auto"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="auto"/>
+                                <ColumnDefinition Width="auto"/>
+                            </Grid.ColumnDefinitions>
+                            <Button x:Name="playPauseButton" Click="PlayPauseButton_Click"  Style="{ThemeResource IconButtonStyle}" Content="&#xE768;" Margin="0,0,8,0"/>
+                            <TextBlock x:Name="startPointText" Text="00:00" VerticalAlignment="Center" Grid.Column="1" />
+                            <controls:RangeSelector VerticalAlignment="Center" x:Name="rangeSelector" Value="0.5" Grid.Column="2" StepFrequency="0.1" ValueChanged="RangeSelector_ValueChanged" RangeChanged="RangeSelector_RangeChanged" Grid.Row="2" Margin="8,0" />
+                            <TextBlock x:Name="endPointText" Text="00:00" Grid.Column="3" VerticalAlignment="Center"/>
 
-                        <Button Grid.Column="4" Margin="8,0,0,0" Style="{ThemeResource IconButtonStyle}" Content="&#xE767;">
-                            <Button.Flyout>
-                                <Flyout x:Name="VolumeFlyout">
-                                    <StackPanel Orientation="Horizontal">
-                                        <Button x:Name="AudioMuteButton" Click="AudioMuteButton_Click" Style="{ThemeResource IconButtonStyle}" HorizontalAlignment="Center" Margin="0,0,12,0" VerticalAlignment="Center">
-                                            <SymbolIcon x:Name="AudioMuteSymbol" Symbol="Volume"/>
-                                        </Button>
-                                        <Slider x:Name="VolumeSlider" HorizontalAlignment="Center" Value="85" ValueChanged="VolumeSlider_ValueChanged" IsThumbToolTipEnabled="False" Margin="0" VerticalAlignment="Center" Width="{ThemeResource MTCHorizontalVolumeSliderWidth}"/>
-                                        <TextBlock x:Name="VolumeValue" HorizontalAlignment="Center" Margin="12,0,0,0" Style="{ThemeResource MediaTextBlockStyle}" Text="{Binding Value, ElementName=VolumeSlider}" VerticalAlignment="Center" Width="24"/>
-                                    </StackPanel>
-                                </Flyout>
-                            </Button.Flyout>
-                        </Button>
+                            <Button Grid.Column="4" Margin="8,0,0,0" Style="{ThemeResource IconButtonStyle}" Content="&#xE767;">
+                                <Button.Flyout>
+                                    <Flyout x:Name="VolumeFlyout">
+                                        <StackPanel Orientation="Horizontal">
+                                            <Button x:Name="AudioMuteButton" Click="AudioMuteButton_Click" Style="{ThemeResource IconButtonStyle}" HorizontalAlignment="Center" Margin="0,0,12,0" VerticalAlignment="Center">
+                                                <SymbolIcon x:Name="AudioMuteSymbol" Symbol="Volume"/>
+                                            </Button>
+                                            <Slider x:Name="VolumeSlider" HorizontalAlignment="Center" Value="85" ValueChanged="VolumeSlider_ValueChanged" IsThumbToolTipEnabled="False" Margin="0" VerticalAlignment="Center" Width="{ThemeResource MTCHorizontalVolumeSliderWidth}"/>
+                                            <TextBlock x:Name="VolumeValue" HorizontalAlignment="Center" Margin="12,0,0,0" Style="{ThemeResource MediaTextBlockStyle}" Text="{Binding Value, ElementName=VolumeSlider}" VerticalAlignment="Center" Width="24"/>
+                                        </StackPanel>
+                                    </Flyout>
+                                </Button.Flyout>
+                            </Button>
+                        </Grid>
                     </Grid>
                 </Grid>
+
             </Grid>
+            <Grid x:Name="overlayGrid" Opacity="0" Background="{ThemeResource OverlayBackdrop}" Visibility="Collapsed">
+                <StackPanel x:Name="overlayContent" RenderTransformOrigin="0.5,0.5" VerticalAlignment="Center" HorizontalAlignment="Center">
+                    <StackPanel.RenderTransform>
+                        <ScaleTransform x:Name="overlayContentScale" ScaleX="0.9" ScaleY="0.9"/>
+                    </StackPanel.RenderTransform>
 
-        </Grid>
-        <Grid x:Name="overlayGrid" Opacity="0" Background="{ThemeResource OverlayBackdrop}" Visibility="Collapsed">
-            <StackPanel x:Name="overlayContent" RenderTransformOrigin="0.5,0.5" VerticalAlignment="Center" HorizontalAlignment="Center">
-                <StackPanel.RenderTransform>
-                    <ScaleTransform x:Name="overlayContentScale" ScaleX="0.9" ScaleY="0.9"/>
-                </StackPanel.RenderTransform>
-
-                <Grid HorizontalAlignment="Center" Width="128" Height="128" Margin="12">
-                    <controls1:RadialProgressBar x:Name="progressRing" Width="128" Height="128" Value="0" Maximum="100"/>
-                    <TextBlock x:Name="progressText" Style="{ThemeResource HeaderTextBlockStyle}" VerticalAlignment="Center" HorizontalAlignment="Center" Text="0"/>
-                    <TextBlock x:Name="completedText" Visibility="Collapsed" Width="64" Height="64" FontSize="64" LineHeight="64" VerticalAlignment="Center" HorizontalAlignment="Center" FontFamily="Segoe MDL2 Assets">
+                    <Grid HorizontalAlignment="Center" Width="128" Height="128" Margin="12">
+                        <controls1:RadialProgressBar x:Name="progressRing" Width="128" Height="128" Value="0" Maximum="100"/>
+                        <TextBlock x:Name="progressText" Style="{ThemeResource HeaderTextBlockStyle}" VerticalAlignment="Center" HorizontalAlignment="Center" Text="0"/>
+                        <TextBlock x:Name="completedText" Visibility="Collapsed" Width="64" Height="64" FontSize="64" LineHeight="64" VerticalAlignment="Center" HorizontalAlignment="Center" FontFamily="Segoe MDL2 Assets">
                         &#xE8FB;
-                    </TextBlock>
-                </Grid>
+                        </TextBlock>
+                    </Grid>
 
-                <TextBlock x:Uid="/VideoEditor/ProcessingVideoheader" Style="{ThemeResource TitleTextBlockStyle}" HorizontalAlignment="Center" />
-                <Button x:Name="cancelButton" Click="CancelButton_Click" Style="{ThemeResource TextBlockButtonStyle}" HorizontalAlignment="Center" Content="Cancel" />
+                    <TextBlock x:Uid="/VideoEditor/ProcessingVideoheader" Style="{ThemeResource TitleTextBlockStyle}" HorizontalAlignment="Center" />
+                    <Button x:Name="cancelButton" Click="CancelButton_Click" Style="{ThemeResource TextBlockButtonStyle}" HorizontalAlignment="Center" Content="Cancel" />
 
-            </StackPanel>
+                </StackPanel>
+            </Grid>
         </Grid>
-    </Grid>
+    </controls1:DropShadowPanel>
 </Page>

--- a/Unicord.Universal/Pages/VideoEditor.xaml.cs
+++ b/Unicord.Universal/Pages/VideoEditor.xaml.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using Microsoft.Toolkit.Uwp.UI.Controls;
 using Unicord.Universal.Models;
+using Unicord.Universal.Services;
 using Unicord.Universal.Utilities;
 using WamWooWam.Core;
 using Windows.ApplicationModel.Resources;
@@ -32,7 +33,7 @@ using Windows.UI.Xaml.Navigation;
 
 namespace Unicord.Universal.Pages
 {
-    public sealed partial class VideoEditor : Page
+    public sealed partial class VideoEditor : Page, IOverlay
     {
         public const string PLAY_GLYPH = "\xE768";
         public const string PAUSE_GLYPH = "\xE769";
@@ -353,7 +354,8 @@ namespace Unicord.Universal.Pages
 
         private async void Close()
         {
-            this.FindParent<DiscordPage>().CloseCustomPane();
+            OverlayService.GetForCurrentView().CloseOverlay();
+
             mediaElement.Source = null;
             _mediaStreamSource = null;
             _playTimer?.Stop();

--- a/Unicord.Universal/Services/BaseService.cs
+++ b/Unicord.Universal/Services/BaseService.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Unicord.Universal.Services
+{
+    internal abstract class BaseService<T> where T: BaseService<T>, new()
+    {
+        private static ThreadLocal<T> _serviceStore
+            = new ThreadLocal<T>(() => new T(), true);
+
+        public static T GetForCurrentView()
+        {
+            var val = _serviceStore.Value;
+            if (!val.isInitialised)
+            {
+                val.Initialise();
+            }
+
+            return val;
+        }
+
+        protected bool isInitialised;
+        protected virtual void Initialise()
+        {
+            isInitialised = true;
+        }
+    }
+}

--- a/Unicord.Universal/Services/BaseService.cs
+++ b/Unicord.Universal/Services/BaseService.cs
@@ -15,7 +15,7 @@ namespace Unicord.Universal.Services
         public static T GetForCurrentView()
         {
             var val = _serviceStore.Value;
-            if (!val.isInitialised)
+            if (!val._isInitialised)
             {
                 val.Initialise();
             }
@@ -23,10 +23,10 @@ namespace Unicord.Universal.Services
             return val;
         }
 
-        protected bool isInitialised;
+        protected bool _isInitialised;
         protected virtual void Initialise()
         {
-            isInitialised = true;
+            _isInitialised = true;
         }
     }
 }

--- a/Unicord.Universal/Services/DiscordNavigationService.cs
+++ b/Unicord.Universal/Services/DiscordNavigationService.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DSharpPlus;
+using DSharpPlus.Entities;
+using Unicord.Universal.Models;
+using Unicord.Universal.Pages;
+using Unicord.Universal.Pages.Subpages;
+using Unicord.Universal.Utilities;
+using Unicord.Universal.Voice;
+using Windows.ApplicationModel.Resources;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media.Animation;
+
+namespace Unicord.Universal.Services
+{
+    /// <summary>
+    /// A service to handle navigation between channels and servers
+    /// </summary>
+    internal class DiscordNavigationService : BaseService<DiscordNavigationService>
+    {
+        private DiscordPage _page;
+        private DiscordPageModel _pageModel;
+
+        protected override void Initialise()
+        {
+            base.Initialise();
+
+            _page = Window.Current.Content.FindChild<DiscordPage>();
+            _pageModel = _page.DataContext as DiscordPageModel;
+        }
+
+        internal async Task NavigateAsync(DiscordChannel channel)
+        {
+            if (_pageModel.CurrentChannel != channel)
+            {
+                _pageModel.Navigating = true;
+                _page.CloseSplitPane(); // pane service?
+
+                _pageModel.SelectedGuild = null;
+                _pageModel.SelectedDM = null;
+
+                // friendsItem.IsSelected = false;
+
+                if (channel == null)
+                {
+                    // friendsItem.IsSelected = true;
+                    _page.SidebarFrame.Navigate(typeof(DMChannelsPage), channel, new DrillInNavigationTransitionInfo());
+                    _page.MainFrame.Navigate(typeof(FriendsPage));
+
+                    return;
+                }
+
+                if (await WindowManager.ActivateOtherWindow(channel))
+                    return;
+
+                if (channel is DiscordDmChannel dm)
+                {
+                    _pageModel.SelectedDM = dm;
+                    // friendsItem.IsSelected = true;
+
+                    if (!(_page.SidebarFrame.Content is DMChannelsPage))
+                        _page.SidebarFrame.Navigate(typeof(DMChannelsPage), channel, new DrillInNavigationTransitionInfo());
+                }
+                else if (channel.Guild != null)
+                {
+                    _pageModel.SelectedGuild = channel.Guild;
+
+                    if (!(_page.SidebarFrame.Content is GuildChannelListPage p) || p.Guild != channel.Guild)
+                        _page.SidebarFrame.Navigate(typeof(GuildChannelListPage), channel.Guild, new DrillInNavigationTransitionInfo());
+                }
+
+                if (channel.IsNSFW)
+                {
+                    var loader = ResourceLoader.GetForViewIndependentUse();
+                    if (await WindowsHelloManager.VerifyAsync(Constants.VERIFY_NSFW, loader.GetString("VerifyNSFWDisplayReason")))
+                    {
+                        if (App.RoamingSettings.Read($"NSFW_{channel.Id}", false) == false || !App.RoamingSettings.Read($"NSFW_All", false))
+                        {
+                            _page.MainFrame.Navigate(typeof(ChannelWarningPage), channel/*, info ?? new SlideNavigationTransitionInfo()*/);
+                        }
+                        else
+                        {
+                            _page.MainFrame.Navigate(typeof(ChannelPage), channel/*, info ?? new SlideNavigationTransitionInfo()*/);
+                        }
+                    }
+                }
+                else
+                {
+                    _page.MainFrame.Navigate(typeof(ChannelPage), channel/*, info ?? new SlideNavigationTransitionInfo()*/);
+                }
+
+                _pageModel.Navigating = false;
+            }
+            else if (channel?.Type == ChannelType.Voice)
+            {
+                try
+                {
+                    var voice = new VoiceConnectionModel(channel);
+                    _pageModel.VoiceModel = voice;
+                    await voice.ConnectAsync();
+                }
+                catch (Exception ex)
+                {
+                    await UIUtilities.ShowErrorDialogAsync("Failed to connect to voice!", ex.Message);
+                }
+            }
+        }
+    }
+}

--- a/Unicord.Universal/Services/DiscordNavigationService.cs
+++ b/Unicord.Universal/Services/DiscordNavigationService.cs
@@ -60,7 +60,7 @@ namespace Unicord.Universal.Services
                 if (channel == null)
                 {
                     _pageModel.IsFriendsSelected = true;
-                    _page.SidebarFrame.Navigate(typeof(DMChannelsPage), channel, new DrillInNavigationTransitionInfo());
+                    _page.SidebarFrame.Navigate(typeof(DMChannelsPage), null, new DrillInNavigationTransitionInfo());
                     _page.MainFrame.Navigate(typeof(FriendsPage));
 
                     return;
@@ -73,9 +73,7 @@ namespace Unicord.Universal.Services
                 {
                     _pageModel.SelectedDM = dm;
                     _pageModel.IsFriendsSelected = true;
-
-                    if (!(_page.SidebarFrame.Content is DMChannelsPage))
-                        _page.SidebarFrame.Navigate(typeof(DMChannelsPage), channel, new DrillInNavigationTransitionInfo());
+                    _page.SidebarFrame.Navigate(typeof(DMChannelsPage), channel, new DrillInNavigationTransitionInfo());
                 }
                 else if (channel.Guild != null)
                 {

--- a/Unicord.Universal/Services/DiscordNavigationService.cs
+++ b/Unicord.Universal/Services/DiscordNavigationService.cs
@@ -47,6 +47,17 @@ namespace Unicord.Universal.Services
 
         internal async Task NavigateAsync(DiscordChannel channel)
         {
+            if (channel == null)
+            {
+                _pageModel.SelectedGuild = null;
+                _pageModel.SelectedDM = null;
+                _pageModel.IsFriendsSelected = true;
+                _page.SidebarFrame.Navigate(typeof(DMChannelsPage), null, new DrillInNavigationTransitionInfo());
+                _page.MainFrame.Navigate(typeof(FriendsPage));
+
+                return;
+            }
+
             if (_pageModel.CurrentChannel != channel && !channel.IsVoice)
             {
                 _pageModel.Navigating = true;
@@ -54,17 +65,7 @@ namespace Unicord.Universal.Services
 
                 _pageModel.SelectedGuild = null;
                 _pageModel.SelectedDM = null;
-
                 _pageModel.IsFriendsSelected = false;
-
-                if (channel == null)
-                {
-                    _pageModel.IsFriendsSelected = true;
-                    _page.SidebarFrame.Navigate(typeof(DMChannelsPage), null, new DrillInNavigationTransitionInfo());
-                    _page.MainFrame.Navigate(typeof(FriendsPage));
-
-                    return;
-                }
 
                 if (await WindowManager.ActivateOtherWindow(channel))
                     return;

--- a/Unicord.Universal/Services/FullscreenService.cs
+++ b/Unicord.Universal/Services/FullscreenService.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Graphics.Display;
+using Windows.UI.Core;
+using Windows.UI.ViewManagement;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Unicord.Universal.Services
+{
+    internal class FullscreenService : BaseService<FullscreenService>
+    {
+        private MainPage _page;
+        private Grid _canvas;
+        private ApplicationView _view;
+
+        private FrameworkElement _fullscreenElement;
+        private Panel _fullscreenParent;
+
+        public event EventHandler<EventArgs> FullscreenEntered;
+        public event EventHandler<EventArgs> FullscreenExited;
+
+        public bool IsFullscreenMode => _view.IsFullScreenMode;
+
+        protected override void Initialise()
+        {
+            _page = Window.Current.Content.FindChild<MainPage>();
+            _canvas = _page?.FindChild<Grid>("fullscreenCanvas");
+            _view = ApplicationView.GetForCurrentView();
+            _isInitialised = true;
+
+            var nav = SystemNavigationManager.GetForCurrentView();
+            nav.BackRequested += OnBackRequested;
+        }
+
+        private void OnBackRequested(object sender, BackRequestedEventArgs e)
+        {
+            if (_canvas.Visibility == Visibility.Visible)
+            {
+                if (_fullscreenElement != null && _fullscreenParent != null)
+                {
+                    LeaveFullscreen(_fullscreenElement, _fullscreenParent);
+                }
+                else
+                {
+                    LeaveFullscreen();
+                }
+
+                e.Handled = true;
+            }
+        }
+
+        public void EnterFullscreen(FrameworkElement element, Panel parent)
+        {
+            _view.TryEnterFullScreenMode();
+            DisplayInformation.AutoRotationPreferences = DisplayOrientations.Landscape | DisplayOrientations.LandscapeFlipped | DisplayOrientations.Portrait;
+
+            parent.Children.Remove(element);
+            _fullscreenElement = element;
+            _fullscreenParent = parent;
+
+            _canvas.Visibility = Visibility.Visible;
+            _canvas.Children.Add(element);
+
+            element.Width = double.NaN;
+            element.Height = double.NaN;
+
+            FullscreenEntered?.Invoke(this, null);
+        }
+
+        public void LeaveFullscreen()
+        {
+            _view.ExitFullScreenMode();
+            DisplayInformation.AutoRotationPreferences = DisplayOrientations.Portrait;
+
+            _fullscreenElement = null;
+            _fullscreenParent = null;
+
+            _canvas.Children.Clear();
+            _canvas.Visibility = Visibility.Collapsed;
+
+            FullscreenExited?.Invoke(this, null);
+        }
+
+        public void LeaveFullscreen(FrameworkElement element, Panel parent)
+        {
+            _view.ExitFullScreenMode();
+            DisplayInformation.AutoRotationPreferences = DisplayOrientations.Portrait;
+
+            _canvas.Children.Remove(element);
+            parent.Children.Insert(0, element);
+            element.Width = double.NaN;
+            element.Height = double.NaN;
+
+            _fullscreenElement = null;
+            _fullscreenParent = null;
+
+            _canvas.Visibility = Visibility.Collapsed;
+
+            FullscreenExited?.Invoke(this, null);
+        }
+    }
+}

--- a/Unicord.Universal/Services/OverlayService.cs
+++ b/Unicord.Universal/Services/OverlayService.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Unicord.Universal.Services
+{
+    class OverlayService : BaseService<OverlayService>
+    {
+    }
+}

--- a/Unicord.Universal/Services/OverlayService.cs
+++ b/Unicord.Universal/Services/OverlayService.cs
@@ -3,10 +3,57 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Animation;
 
 namespace Unicord.Universal.Services
 {
-    class OverlayService : BaseService<OverlayService>
+    internal class OverlayService : BaseService<OverlayService>
     {
+        private MainPage _mainPage;
+        private SystemNavigationManager _systemNavigationManager;
+        private bool _overlayVisible;
+
+        protected override void Initialise()
+        {
+            _mainPage = Window.Current.Content.FindChild<MainPage>();
+            _systemNavigationManager = SystemNavigationManager.GetForCurrentView();
+        }
+
+        public void ShowOverlay<T>(object model = null) where T : Page, IOverlay, new()
+        {
+            if (_overlayVisible)
+                throw new InvalidOperationException("Can't show an overlay when one is already visible!");
+
+            _overlayVisible = true;
+            _systemNavigationManager.BackRequested += OnBackRequested;
+
+            _mainPage.CustomFrame.Navigate(typeof(T), model, new SuppressNavigationTransitionInfo());
+            _mainPage.ShowCustomOverlay();
+        }
+
+        internal void CloseOverlay()
+        {
+            if (!_overlayVisible)
+                return;
+
+            _systemNavigationManager.BackRequested -= OnBackRequested;
+            _mainPage.HideCustomOverlay();
+            _overlayVisible = false;
+        }
+
+        private void OnBackRequested(object sender, BackRequestedEventArgs e)
+        {
+            CloseOverlay();
+        }
+    }
+
+    internal interface IOverlay
+    {
+        object DataContext { get; set; }
+        double MaxWidth { get; set; }
+        double MaxHeight { get; set; }
     }
 }

--- a/Unicord.Universal/Services/SwipeOpenService.cs
+++ b/Unicord.Universal/Services/SwipeOpenService.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Unicord.Universal.Pages;
+using Unicord.Universal.Utilities;
+using Windows.UI.Xaml;
+
+
+namespace Unicord.Universal.Services
+{
+    internal class SwipeOpenService : BaseService<SwipeOpenService>
+    {
+        internal SwipeOpenHelper Helper { get; set; }
+
+        protected override void Initialise()
+        {
+            Helper = Window.Current.Content.FindChild<DiscordPage>()?.helper;
+        }
+
+        public void AddAdditionalElement(UIElement element) => Helper?.AddAdditionalElement(element);
+    }
+}

--- a/Unicord.Universal/Tools.cs
+++ b/Unicord.Universal/Tools.cs
@@ -117,7 +117,7 @@ namespace Unicord.Universal
                 {
                     return t;
                 }
-                else if ((child = FindChild<T>(child, controlName)) != default)
+                else if ((child = FindChild<T>(child, controlName)) != null)
                 {
                     return child as T;
                 }
@@ -167,8 +167,7 @@ namespace Unicord.Universal
 
         public static async Task SendFilesWithProgressAsync(DiscordChannel channel, string message, Dictionary<string, IInputStream> files, IProgress<double?> progress)
         {
-            var httpRequestMessage
-                = new HttpRequestMessage(HttpMethod.Post, new Uri("https://discordapp.com/api/v7" + string.Format("/channels/{0}/messages", channel.Id)));
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri($"https://discordapp.com/api/v7/channels/{channel.Id}/messages"));
             httpRequestMessage.Headers.Add("Authorization", DSharpPlus.Utilities.GetFormattedToken(channel.Discord));
 
             var cont = new HttpMultipartFormDataContent();
@@ -189,18 +188,19 @@ namespace Unicord.Universal
             var send = _httpClient.Value.SendRequestAsync(httpRequestMessage);
             send.Progress += new AsyncOperationProgressHandler<HttpResponseMessage, HttpProgress>((o, e) =>
             {
-                progress.Report((e.BytesSent / (double)e.TotalBytesToSend) * 100);
+                if (e.TotalBytesToSend != null)
+                    progress.Report((e.BytesSent / (double)e.TotalBytesToSend) * 100);
             });
 
             await send;
         }
 
         /// <summary>
-        /// Returns true if <paramref name="current"/> is higher in the role heirarchy than <paramref name="member"/>.
+        /// Returns true if <paramref name="current"/> is higher in the role hierarchy than <paramref name="member"/>.
         /// </summary>
         /// <param name="current">The current guild member</param>
         /// <param name="member">The guild member to check against</param>
-        public static bool CheckRoleHeirarchy(DiscordMember current, DiscordMember member)
+        public static bool CheckRoleHierarchy(DiscordMember current, DiscordMember member)
         {
             if (member == null || current == null)
             {

--- a/Unicord.Universal/Unicord.Universal.csproj
+++ b/Unicord.Universal/Unicord.Universal.csproj
@@ -411,6 +411,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\BaseService.cs" />
     <Compile Include="Services\DiscordNavigationService.cs" />
+    <Compile Include="Services\FullscreenService.cs" />
     <Compile Include="SharedTools.cs" />
     <Compile Include="Resources\Templates.xaml.cs">
       <DependentUpon>Templates.xaml</DependentUpon>

--- a/Unicord.Universal/Unicord.Universal.csproj
+++ b/Unicord.Universal/Unicord.Universal.csproj
@@ -24,7 +24,7 @@
     <PackageCertificateThumbprint>97080CF5D53F829FCBD95E3776AB7222AC0E1156</PackageCertificateThumbprint>
     <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <AppxBundle>Always</AppxBundle>
-    <AppxBundlePlatforms>x64</AppxBundlePlatforms>
+    <AppxBundlePlatforms>x86|x64|arm</AppxBundlePlatforms>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
     <AppxSymbolPackageEnabled>True</AppxSymbolPackageEnabled>
     <NullableContextOptions>disable</NullableContextOptions>
@@ -418,6 +418,7 @@
       <DependentUpon>Templates.xaml</DependentUpon>
     </Compile>
     <Compile Include="Utilities\AdaptiveFlyout.cs" />
+    <Compile Include="Utilities\SwipeOpenHelper.cs" />
     <Compile Include="Utilities\ThemeManager.cs" />
     <Compile Include="Tools.cs" />
     <Compile Include="Integration\WindowsHelloManager.cs" />

--- a/Unicord.Universal/Unicord.Universal.csproj
+++ b/Unicord.Universal/Unicord.Universal.csproj
@@ -409,6 +409,8 @@
       <DependentUpon>VideoEditor.xaml</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Services\BaseService.cs" />
+    <Compile Include="Services\DiscordNavigationService.cs" />
     <Compile Include="SharedTools.cs" />
     <Compile Include="Resources\Templates.xaml.cs">
       <DependentUpon>Templates.xaml</DependentUpon>

--- a/Unicord.Universal/Unicord.Universal.csproj
+++ b/Unicord.Universal/Unicord.Universal.csproj
@@ -355,6 +355,12 @@
     </Compile>
     <Compile Include="Models\ChannelEditViewModel.cs" />
     <Compile Include="Models\MessagingSettingsModel.cs" />
+    <Compile Include="Pages\Management\Channel\ChannelEditOverviewPage.xaml.cs">
+      <DependentUpon>ChannelEditOverviewPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Pages\Management\Channel\ChannelEditPermissionsPage.xaml.cs">
+      <DependentUpon>ChannelEditPermissionsPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Pages\Settings\MessagingSettingsPage.xaml.cs">
       <DependentUpon>MessagingSettingsPage.xaml</DependentUpon>
     </Compile>
@@ -413,6 +419,7 @@
     <Compile Include="Services\DiscordNavigationService.cs" />
     <Compile Include="Services\FullscreenService.cs" />
     <Compile Include="Services\OverlayService.cs" />
+    <Compile Include="Services\SwipeOpenService.cs" />
     <Compile Include="SharedTools.cs" />
     <Compile Include="Resources\Templates.xaml.cs">
       <DependentUpon>Templates.xaml</DependentUpon>
@@ -687,6 +694,14 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Pages\Management\Channel\ChannelEditOverviewPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Pages\Management\Channel\ChannelEditPermissionsPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Pages\Settings\MessagingSettingsPage.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -842,6 +857,7 @@
       <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/Unicord.Universal/Unicord.Universal.csproj
+++ b/Unicord.Universal/Unicord.Universal.csproj
@@ -412,6 +412,7 @@
     <Compile Include="Services\BaseService.cs" />
     <Compile Include="Services\DiscordNavigationService.cs" />
     <Compile Include="Services\FullscreenService.cs" />
+    <Compile Include="Services\OverlayService.cs" />
     <Compile Include="SharedTools.cs" />
     <Compile Include="Resources\Templates.xaml.cs">
       <DependentUpon>Templates.xaml</DependentUpon>

--- a/Unicord.Universal/Unicord.Universal.csproj
+++ b/Unicord.Universal/Unicord.Universal.csproj
@@ -24,16 +24,20 @@
     <PackageCertificateThumbprint>97080CF5D53F829FCBD95E3776AB7222AC0E1156</PackageCertificateThumbprint>
     <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <AppxBundle>Always</AppxBundle>
-    <AppxBundlePlatforms>x86|x64|arm</AppxBundlePlatforms>
+    <AppxBundlePlatforms>x86|x64|arm|arm64</AppxBundlePlatforms>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
     <AppxSymbolPackageEnabled>True</AppxSymbolPackageEnabled>
     <NullableContextOptions>disable</NullableContextOptions>
-    <AppInstallerUpdateFrequency>1</AppInstallerUpdateFrequency>
+    <AppInstallerUpdateFrequency>0</AppInstallerUpdateFrequency>
     <AppInstallerCheckForUpdateFrequency>OnApplicationRun</AppInstallerCheckForUpdateFrequency>
     <HockeyAppResourceId>b87a8458e7a24a688e6c3a2d11d08657</HockeyAppResourceId>
     <AppxWinMdCacheEnabled>false</AppxWinMdCacheEnabled>
     <AppxBundleAutoResourcePackageQualifiers>
     </AppxBundleAutoResourcePackageQualifiers>
+    <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
+    <PackageCertificatePassword />
+    <GenerateTestArtifacts>True</GenerateTestArtifacts>
+    <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/Unicord.Universal/Utilities/SwipeOpenHelper.cs
+++ b/Unicord.Universal/Utilities/SwipeOpenHelper.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Input;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Animation;
+
+namespace Unicord.Universal.Utilities
+{
+    internal class SwipeOpenHelper
+    {
+        private GestureRecognizer _recogniser;
+        private UIElement _target;
+        private UIElement _reference;
+        private TranslateTransform _transform;
+        private Storyboard _openAnimation;
+        private Storyboard _closeAnimation;
+        private double _xTotal = 0.0;
+
+        public bool IsEnabled { get; set; }
+
+        public SwipeOpenHelper(UIElement target, UIElement reference, Storyboard openAnimation, Storyboard closeAnimation)
+        {
+            _recogniser = new GestureRecognizer() { GestureSettings = GestureSettings.ManipulationTranslateX };
+            _target = target;
+            _reference = reference;
+            _transform = _target.RenderTransform as TranslateTransform;
+            _openAnimation = openAnimation;
+            _closeAnimation = closeAnimation;
+
+            target.PointerPressed += OnPointerPressed;
+            target.PointerMoved += OnPointerMoved;
+            target.PointerReleased += OnPointerReleased;
+            target.PointerCanceled += OnPointerCanceled;
+
+            _recogniser.ManipulationStarted += OnManipulationStarted;
+            _recogniser.ManipulationUpdated += OnManipulationUpdated;
+            _recogniser.ManipulationCompleted += OnManipulationCompleted;
+        }
+
+        private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
+        {
+            if (!IsEnabled)
+                return;
+
+            _target.CapturePointer(e.Pointer);
+            _recogniser.ProcessDownEvent(e.GetCurrentPoint(_target));
+        }
+
+        private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
+        {
+            if (!IsEnabled)
+                return;
+
+            _recogniser.ProcessMoveEvents(e.GetIntermediatePoints(_reference));
+        }
+
+        private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
+        {
+            if (!IsEnabled)
+                return;
+
+            _recogniser.ProcessUpEvent(e.GetCurrentPoint(_target));
+            _target.ReleasePointerCapture(e.Pointer);
+        }
+
+        private void OnPointerCanceled(object sender, PointerRoutedEventArgs e)
+        {
+            if (!IsEnabled)
+                return;
+
+            _recogniser.CompleteGesture();
+            _target.ReleasePointerCapture(e.Pointer);
+        }
+
+        private void OnManipulationStarted(GestureRecognizer sender, ManipulationStartedEventArgs args)
+        {
+            if (!IsEnabled)
+                return;
+
+            _xTotal = _transform.X;
+        }
+
+        private void OnManipulationUpdated(GestureRecognizer sender, ManipulationUpdatedEventArgs args)
+        {
+            if (!IsEnabled)
+                return;
+
+            _xTotal += args.Delta.Translation.X;
+
+            if (_xTotal > 16)
+            {
+                var delta = Math.Max(Math.Abs(276 - _xTotal), 64) / 64d;
+                _transform.X = Math.Min(_xTotal, 276);
+            }
+        }
+
+        private void OnManipulationCompleted(GestureRecognizer sender, ManipulationCompletedEventArgs args)
+        {
+            if (!IsEnabled)
+                return;
+
+            if (_xTotal > 128)
+            {
+                _openAnimation.Begin();
+            }
+            else
+            {
+                _closeAnimation.Begin();
+            }
+
+            _xTotal = 0;
+        }
+    }
+}

--- a/Unicord.Universal/Utilities/SwipeOpenHelper.cs
+++ b/Unicord.Universal/Utilities/SwipeOpenHelper.cs
@@ -13,18 +13,29 @@ namespace Unicord.Universal.Utilities
 {
     internal class SwipeOpenHelper
     {
+        private class AdditionalElementHandlerData
+        {
+            public PointerEventHandler Pressed;
+            public PointerEventHandler Moved;
+            public PointerEventHandler Released;
+            public PointerEventHandler Cancelled;
+        }
+
         private GestureRecognizer _recogniser;
         private UIElement _target;
         private UIElement _reference;
         private TranslateTransform _transform;
         private Storyboard _openAnimation;
         private Storyboard _closeAnimation;
+        private Dictionary<UIElement, AdditionalElementHandlerData> _attachedElements;
         private double _xTotal = 0.0;
+        private bool _isActive;
 
         public bool IsEnabled { get; set; }
 
         public SwipeOpenHelper(UIElement target, UIElement reference, Storyboard openAnimation, Storyboard closeAnimation)
         {
+            _attachedElements = new Dictionary<UIElement, AdditionalElementHandlerData>();
             _recogniser = new GestureRecognizer() { GestureSettings = GestureSettings.ManipulationTranslateX };
             _target = target;
             _reference = reference;
@@ -32,23 +43,59 @@ namespace Unicord.Universal.Utilities
             _openAnimation = openAnimation;
             _closeAnimation = closeAnimation;
 
-            target.PointerPressed += OnPointerPressed;
-            target.PointerMoved += OnPointerMoved;
-            target.PointerReleased += OnPointerReleased;
-            target.PointerCanceled += OnPointerCanceled;
+            target.AddHandler(UIElement.PointerPressedEvent, new PointerEventHandler(OnPointerPressed), false);
+            target.AddHandler(UIElement.PointerMovedEvent, new PointerEventHandler(OnPointerMoved), false);
+            target.AddHandler(UIElement.PointerReleasedEvent, new PointerEventHandler(OnPointerReleased), false);
+            target.AddHandler(UIElement.PointerCanceledEvent, new PointerEventHandler(OnPointerCanceled), false);
 
             _recogniser.ManipulationStarted += OnManipulationStarted;
             _recogniser.ManipulationUpdated += OnManipulationUpdated;
             _recogniser.ManipulationCompleted += OnManipulationCompleted;
         }
 
+        public void AddAdditionalElement(UIElement element, bool handled = true)
+        {
+            var data = new AdditionalElementHandlerData()
+            {
+                Pressed = new PointerEventHandler(OnPointerPressed),
+                Moved = new PointerEventHandler(OnPointerMoved),
+                Released = new PointerEventHandler(OnPointerReleased),
+                Cancelled = new PointerEventHandler(OnPointerCanceled)
+            };
+
+            if (_attachedElements.TryAdd(element, data))
+            {
+                element.AddHandler(UIElement.PointerPressedEvent, data.Pressed, handled);
+                element.AddHandler(UIElement.PointerMovedEvent, data.Moved, handled);
+                element.AddHandler(UIElement.PointerReleasedEvent, data.Released, handled);
+                element.AddHandler(UIElement.PointerCanceledEvent, data.Cancelled, handled);
+
+                if (element is FrameworkElement fuck)
+                {
+                    fuck.Unloaded += OnAdditionalElementUnloaded;
+                }
+            }
+        }
+
+        private void OnAdditionalElementUnloaded(object sender, RoutedEventArgs e)
+        {
+            var element = sender as UIElement;
+            var data = _attachedElements[element];
+            (sender as FrameworkElement).Unloaded -= OnAdditionalElementUnloaded;
+
+            element.RemoveHandler(UIElement.PointerPressedEvent, data.Pressed);
+            element.RemoveHandler(UIElement.PointerMovedEvent, data.Moved);
+            element.RemoveHandler(UIElement.PointerReleasedEvent, data.Released);
+            element.RemoveHandler(UIElement.PointerCanceledEvent, data.Cancelled);
+        }
+
         private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
         {
-            if (!IsEnabled)
+            if (!IsEnabled || _recogniser.IsActive)
                 return;
 
-            _target.CapturePointer(e.Pointer);
-            _recogniser.ProcessDownEvent(e.GetCurrentPoint(_target));
+            (sender as UIElement).CapturePointer(e.Pointer);
+            _recogniser.ProcessDownEvent(e.GetCurrentPoint(sender as UIElement));
         }
 
         private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
@@ -64,7 +111,7 @@ namespace Unicord.Universal.Utilities
             if (!IsEnabled)
                 return;
 
-            _recogniser.ProcessUpEvent(e.GetCurrentPoint(_target));
+            _recogniser.ProcessUpEvent(e.GetCurrentPoint(sender as UIElement));
             _target.ReleasePointerCapture(e.Pointer);
         }
 
@@ -93,9 +140,12 @@ namespace Unicord.Universal.Utilities
             _xTotal += args.Delta.Translation.X;
 
             if (_xTotal > 16)
+                _isActive = true;
+
+            if (_isActive)
             {
-                var delta = Math.Max(Math.Abs(276 - _xTotal), 64) / 64d;
-                _transform.X = Math.Min(_xTotal, 276);
+                //var delta = Math.Max(Math.Abs(276 - _xTotal), 64) / 64d;
+                _transform.X = Math.Max(Math.Min(_xTotal, 276), 0);
             }
         }
 
@@ -113,6 +163,14 @@ namespace Unicord.Universal.Utilities
                 _closeAnimation.Begin();
             }
 
+            _xTotal = 0;
+            _isActive = false;
+        }
+
+        internal void Cancel()
+        {
+            _recogniser.CompleteGesture();
+            _isActive = false;
             _xTotal = 0;
         }
     }

--- a/Unicord.Universal/Utilities/WindowManager.cs
+++ b/Unicord.Universal/Utilities/WindowManager.cs
@@ -92,10 +92,9 @@ namespace Unicord.Universal.Utilities
             {
                 var coreWindow = coreView.CoreWindow;
                 var window = Window.Current;
+                try { ThemeManager.LoadCurrentTheme(App.Current.Resources); } catch { }
 
                 var frame = new Frame();
-                try { ThemeManager.LoadCurrentTheme(frame.Resources); } catch { }
-
                 window.Content = frame;
                 window.Activate();
 
@@ -119,7 +118,6 @@ namespace Unicord.Universal.Utilities
                 applicationView.Consolidated += OnConsolidated;
             });
 
-            //var prefs = ViewModePreferences.CreateDefault(ApplicationViewMode.Default);
             await ApplicationViewSwitcher.TryShowAsViewModeAsync(viewId, mode);
         }
 


### PR DESCRIPTION
`DiscordPage.xaml.cs` was a total mess that dealt with numerous different things, including, but not limited to: 
 - Multiple types of overlay
 - Entering and exiting fullscreen
 - Navigation between channels
 - Attachment viewing
 - Numerous things that could've been in `DiscordPageModel.cs` 
and more besides.

This PR aims to remove most of these things from that class, and separate them out into multiple different "Services" accessible from the rest of the app, as well as move towards a more MVVM model of programming.