### PR TITLE
Ensure back button on image zoom is visible over the black background

### DIFF
--- a/Unicord.Universal/Pages/Overlay/AttachmentOverlayPage.xaml
+++ b/Unicord.Universal/Pages/Overlay/AttachmentOverlayPage.xaml
@@ -68,7 +68,7 @@
         </Grid>
 
         <Grid Margin="8" VerticalAlignment="Top">
-            <Button Style="{ThemeResource IconButtonStyle}" Content="&#xE72B;" x:Name="backButton" Click="backButton_Click">
+            <Button Style="{ThemeResource IconButtonStyle}" Foreground="White" Content="&#xE72B;" x:Name="backButton" Click="backButton_Click">
                 <w1709:Button.KeyboardAccelerators>
                     <w1709:KeyboardAccelerator Key="Escape"/>
                 </w1709:Button.KeyboardAccelerators>


### PR DESCRIPTION
Current look:
![image](https://github.com/user-attachments/assets/4eb80f89-2001-46ea-a82a-35651252b9b0)
