### PR TITLE
UI enhancements and server navigation improvement

### DIFF
--- a/Unicord.Universal/Controls/Channels/ChannelPageHeaderControl.xaml
+++ b/Unicord.Universal/Controls/Channels/ChannelPageHeaderControl.xaml
@@ -55,7 +55,7 @@
                     <!--  because VisualStateManager is wank  -->
                     <Grid x:Name="ShowSidebarButtonContainer" Margin="4,0,-4,0">
                         <Button x:Name="ShowSidebarButton"
-                                Content="&#xE700;"
+                                Content="&#xE72B;"
                                 Command="{x:Bind ViewModel.LeftPaneCommand}"
                                 Style="{ThemeResource IconButtonStyle}" />
                     </Grid>
@@ -128,15 +128,6 @@
                             <w1709:KeyboardAccelerator Modifiers="Control" Key="M"/>
                         </w1709:ToggleButton.KeyboardAccelerators>
                     </ToggleButton>
-                    <Button x:Name="SearchButton"
-                            x:Uid="/ChannelPage/SearchButton"
-                            Command="{x:Bind ViewModel.SearchCommand}"
-                            Content="&#xE721;"
-                            Style="{ThemeResource ChannelPageHeaderButtonStyle}">
-                        <w1709:Button.KeyboardAccelerators>
-                            <w1709:KeyboardAccelerator Modifiers="Control" Key="S"/>
-                        </w1709:Button.KeyboardAccelerators>
-                    </Button>
                     <Button x:Name="PinsButton"
                             x:Uid="/ChannelPage/PinsButton"
                             x:Load="{x:Bind ViewModel.ShowPinsButton}"
@@ -155,6 +146,15 @@
                             Style="{ThemeResource ChannelPageHeaderButtonStyle}">
                         <w1709:Button.KeyboardAccelerators>
                             <w1709:KeyboardAccelerator Modifiers="Control" Key="U"/>
+                        </w1709:Button.KeyboardAccelerators>
+                    </Button>
+                    <Button x:Name="SearchButton"
+                            x:Uid="/ChannelPage/SearchButton"
+                            Command="{x:Bind ViewModel.SearchCommand}"
+                            Content="&#xE721;"
+                            Style="{ThemeResource ChannelPageHeaderButtonStyle}">
+                        <w1709:Button.KeyboardAccelerators>
+                            <w1709:KeyboardAccelerator Modifiers="Control" Key="S"/>
                         </w1709:Button.KeyboardAccelerators>
                     </Button>
 

--- a/Unicord.Universal/Models/Channels/SearchPageViewModel.cs
+++ b/Unicord.Universal/Models/Channels/SearchPageViewModel.cs
@@ -21,24 +21,28 @@ namespace Unicord.Universal.Models.Channels
         private bool _waitingForIndex;
         private bool _isSearching;
         private int _totalMessages;
+        private bool _hasSearched;
 
         public bool IsSearching
         {
             get => _isSearching;
-            set => OnPropertySet(ref _isSearching, value);
+            set => OnPropertySet(ref _isSearching, value, nameof(IsSearching), nameof(NoResults));
         }
 
         public bool WaitingForIndex
         {
             get => _waitingForIndex;
-            set => OnPropertySet(ref _waitingForIndex, value);
+            set => OnPropertySet(ref _waitingForIndex, value, nameof(WaitingForIndex), nameof(NoResults));
         }
 
         public int TotalMessages
         {
             get => _totalMessages;
-            set => OnPropertySet(ref _totalMessages, value, nameof(TotalMessages), nameof(TotalMessagesString), nameof(CanGoBack), nameof(CanGoForward));
+            set => OnPropertySet(ref _totalMessages, value, nameof(TotalMessages), nameof(TotalMessagesString), nameof(CanGoBack), nameof(CanGoForward), nameof(NoResults));
         }
+
+        public bool NoResults =>
+            _hasSearched && !IsSearching && TotalMessages == 0 && !WaitingForIndex;
 
         public int CurrentPage
         {
@@ -74,6 +78,7 @@ namespace Unicord.Universal.Models.Channels
         {
             await _semaphore.WaitAsync();
 
+            _hasSearched = true;
             IsSearching = true;
             ViewSource.Source = Array.Empty<object>();
 

--- a/Unicord.Universal/Pages/DiscordPage.xaml.cs
+++ b/Unicord.Universal/Pages/DiscordPage.xaml.cs
@@ -256,6 +256,12 @@ namespace Unicord.Universal.Pages
                     }
 
                     Model.IsFriendsSelected = false;
+
+                    // Close sidebar in narrow mode after guild selection
+                    if (Window.Current.Bounds.Width <= SplitPaneService.TWO_PANE_BREAKPOINT)
+                    {
+                        SplitPaneService.GetForCurrentView().ToggleLeftPane();
+                    }
                 }
                 else
                 {

--- a/Unicord.Universal/Pages/Subpages/FriendsPage.xaml
+++ b/Unicord.Universal/Pages/Subpages/FriendsPage.xaml
@@ -93,7 +93,7 @@
                     Click="ShowSidebarButton_Click" 
                     VerticalAlignment="Center"
                     Style="{ThemeResource IconButtonStyle}" 
-                    Content="&#xE700;"/>
+                    Content="&#xE72B;"/>
 
             <TextBlock x:Uid="/FriendsPage/FriendsHeader" 
                        FontFamily="XamlAutoFontFamily"

--- a/Unicord.Universal/Pages/Subpages/PinsPage.xaml
+++ b/Unicord.Universal/Pages/Subpages/PinsPage.xaml
@@ -25,9 +25,22 @@
         </Grid.RowDefinitions>
 
         <Grid x:Name="TopGrid" Height="42">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Button x:Name="CloseButton" 
+                    Grid.Column="0" 
+                    Content="&#xE89F;"
+                    FontFamily="{StaticResource SymbolThemeFontFamily}"
+                    Style="{ThemeResource IconButtonStyle}"
+                    Margin="{ThemeResource RightPaneCloseButton_Margin}"
+                    Padding="8"
+                    Click="CloseButton_Click" />
             <TextBlock
                 x:Uid="/PinsPage/PinsHeader"
-                Margin="12,0"
+                Grid.Column="1"
+                Margin="{ThemeResource RightPaneHeader_Margin}"
                 VerticalAlignment="Center"
                 FontSize="16"
                 FontWeight="Bold"/>

--- a/Unicord.Universal/Pages/Subpages/PinsPage.xaml.cs
+++ b/Unicord.Universal/Pages/Subpages/PinsPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Unicord.Universal.Models.Channels;
+using Unicord.Universal.Services;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 
@@ -6,6 +7,8 @@ namespace Unicord.Universal.Pages.Subpages
 {
     public sealed partial class PinsPage : Page
     {
+        private ChannelViewModel _channel;
+
         public PinsPage()
         {
             InitializeComponent();
@@ -15,8 +18,14 @@ namespace Unicord.Universal.Pages.Subpages
         {
             if (e.Parameter is ChannelViewModel channel)
             {
+                _channel = channel;
                 DataContext = new PinsPageViewModel(channel);
             }
+        }
+
+        private void CloseButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            SplitPaneService.GetForCurrentView().ToggleRightPane<PinsPage>(_channel);
         }
     }
 }

--- a/Unicord.Universal/Pages/Subpages/SearchPage.xaml
+++ b/Unicord.Universal/Pages/Subpages/SearchPage.xaml
@@ -29,15 +29,16 @@
             </Grid.ColumnDefinitions>
             <Button x:Name="CloseButton" 
                     Grid.Column="0" 
-                    Content="&#xE700;"
+                    Content="&#xE89F;"
                     FontFamily="{StaticResource SymbolThemeFontFamily}"
                     Style="{ThemeResource IconButtonStyle}"
+                    Margin="{ThemeResource RightPaneCloseButton_Margin}"
                     Padding="8"
                     Click="CloseSearch_Click" />
             <TextBlock x:Uid="/SearchPage/SearchHeader"
                        Grid.Column="1"
                        Text="Search"
-                       Margin="12,0"
+                       Margin="{ThemeResource RightPaneHeader_Margin}"
                        VerticalAlignment="Center"
                        FontSize="16"
                        FontWeight="Bold"/>
@@ -51,10 +52,11 @@
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
-            <TextBox x:Name="SearchBox" 
+            <AutoSuggestBox x:Name="SearchBox" 
                      x:Uid="/SearchPage/SearchBox" 
-                     InputScope="Search" 
-                     VerticalAlignment="Center" 
+                     VerticalAlignment="Center"
+                     QueryIcon="Find"
+                     QuerySubmitted="SearchBox_QuerySubmitted"
                      KeyDown="SearchBox_KeyDown" />
 
             <Button x:Name="SearchButton" 
@@ -63,6 +65,7 @@
                     Content="&#xE721;"
                     FontFamily="{StaticResource SymbolThemeFontFamily}"
                     Padding="8"
+                    Visibility="Collapsed"
                     Click="SearchButton_Click" />
 
             <Button x:Name="ExpandOptionsButton" 
@@ -77,6 +80,17 @@
         <Grid x:Name="ExtraOptionsGrid"
               Grid.Row="2">
         </Grid>
+
+        <StackPanel x:Name="noResults"
+                    Grid.Row="3"
+                    Margin="15"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Visibility="{Binding NoResults, Converter={StaticResource BoolVisibilityConverter}}">
+            <TextBlock FontSize="110" Text=":(" />
+            <TextBlock x:Uid="/SearchPage/NoResultsHeader" Style="{ThemeResource SubheaderTextBlockStyle}"/>
+            <TextBlock x:Uid="/SearchPage/NoResultsSubheader" TextWrapping="Wrap"/>
+        </StackPanel>
 
         <ListView x:Name="SearchResultsView"
                   BorderThickness="0,1"

--- a/Unicord.Universal/Pages/Subpages/UserListPage.xaml
+++ b/Unicord.Universal/Pages/Subpages/UserListPage.xaml
@@ -22,9 +22,22 @@
         </Grid.RowDefinitions>
 
         <Grid x:Name="topGrid" Height="42">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Button x:Name="CloseButton" 
+                    Grid.Column="0" 
+                    Content="&#xE89F;"
+                    FontFamily="{StaticResource SymbolThemeFontFamily}"
+                    Style="{ThemeResource IconButtonStyle}"
+                    Margin="{ThemeResource RightPaneCloseButton_Margin}"
+                    Padding="8"
+                    Click="CloseButton_Click" />
             <TextBlock
                 x:Uid="/UserListPage/UserListHeader"
-                Margin="12,0"
+                Grid.Column="1"
+                Margin="{ThemeResource RightPaneHeader_Margin}"
                 VerticalAlignment="Center"
                 FontSize="16"
                 FontWeight="Bold"/>

--- a/Unicord.Universal/Pages/Subpages/UserListPage.xaml.cs
+++ b/Unicord.Universal/Pages/Subpages/UserListPage.xaml.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using DSharpPlus.Entities;
 using Unicord.Universal.Models.Channels;
 using Unicord.Universal.Models.User;
+using Unicord.Universal.Services;
 using Windows.UI.Core;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
@@ -11,6 +12,8 @@ namespace Unicord.Universal.Pages.Subpages
 {
     public sealed partial class UserListPage : Page
     {
+        private ChannelViewModel _channel;
+
         public UserListPage()
         {
             InitializeComponent();
@@ -25,6 +28,7 @@ namespace Unicord.Universal.Pages.Subpages
 
                 if (e.Parameter is ChannelViewModel channel)
                 {
+                    _channel = channel;
                     await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                     {
                         if (channel.Channel is DiscordDmChannel dm)
@@ -63,6 +67,11 @@ namespace Unicord.Universal.Pages.Subpages
             //    //AdaptiveFlyoutUtilities.ShowAdaptiveFlyout<UserFlyout>(item, element as FrameworkElement);
             //    userList.SelectedItem = null;
             //}
+        }
+
+        private void CloseButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            SplitPaneService.GetForCurrentView().ToggleRightPane<UserListPage>(_channel);
         }
     }
 }

--- a/Unicord.Universal/Resources/en-GB/SearchPage.resw
+++ b/Unicord.Universal/Resources/en-GB/SearchPage.resw
@@ -120,6 +120,12 @@
   <data name="ResultsText.Text" xml:space="preserve">
     <value>results</value>
   </data>
+  <data name="NoResultsHeader.Text" xml:space="preserve">
+    <value>We searched far and wide.</value>
+  </data>
+  <data name="NoResultsSubheader.Text" xml:space="preserve">
+    <value>Unfortunately, no results were found.</value>
+  </data>
   <data name="SearchBox.PlaceholderText" xml:space="preserve">
     <value>Search...</value>
   </data>

--- a/Unicord.Universal/Resources/en-US/SearchPage.resw
+++ b/Unicord.Universal/Resources/en-US/SearchPage.resw
@@ -120,6 +120,12 @@
   <data name="ResultsText.Text" xml:space="preserve">
     <value>results</value>
   </data>
+  <data name="NoResultsHeader.Text" xml:space="preserve">
+    <value>We searched far and wide.</value>
+  </data>
+  <data name="NoResultsSubheader.Text" xml:space="preserve">
+    <value>Unfortunately, no results were found.</value>
+  </data>
   <data name="SearchBox.PlaceholderText" xml:space="preserve">
     <value>Search...</value>
   </data>

--- a/Unicord.Universal/Resources/ja-JP/SearchPage.resw
+++ b/Unicord.Universal/Resources/ja-JP/SearchPage.resw
@@ -120,6 +120,12 @@
   <data name="ResultsText.Text" xml:space="preserve">
     <value>検索結果</value>
   </data>
+  <data name="NoResultsHeader.Text" xml:space="preserve">
+    <value>あちこち探しました。</value>
+  </data>
+  <data name="NoResultsSubheader.Text" xml:space="preserve">
+    <value>残念ながら、結果が見つかりませんでした。</value>
+  </data>
   <data name="SearchBox.PlaceholderText" xml:space="preserve">
     <value>検索...</value>
   </data>

--- a/Unicord.Universal/Resources/ru-RU/SearchPage.resw
+++ b/Unicord.Universal/Resources/ru-RU/SearchPage.resw
@@ -120,6 +120,12 @@
     <data name="ResultsText.Text" xml:space="preserve">
     <value>Результаты</value>
     </data>
+  <data name="NoResultsHeader.Text" xml:space="preserve">
+    <value>Мы искали повсюду.</value>
+  </data>
+  <data name="NoResultsSubheader.Text" xml:space="preserve">
+    <value>К сожалению, результаты не найдены.</value>
+  </data>
 <data name="SearchBox.PlaceholderText" xml:space="preserve">
   <value>Поиск...</value>
 </data>

--- a/Unicord.Universal/Themes/Colours.xaml
+++ b/Unicord.Universal/Themes/Colours.xaml
@@ -20,7 +20,7 @@
             <Color x:Key="BackgroundPrimaryColour">#FF0F0F0F</Color>
             <Color x:Key="BackgroundSecondaryColour">#FF181818</Color>
             <Color x:Key="BackgroundTertiaryColour">#FF1C1C1C</Color>
-            <SolidColorBrush x:Key="ErrorTextForegroundBrush" Color="#FFFFF000"/>
+            <SolidColorBrush x:Key="ErrorTextForegroundBrush" Color="#FFF23F42"/>
             <LinearGradientBrush x:Key="BackgroundGradientBrush" StartPoint="0.5,0" EndPoint="0.5,1">
                 <GradientStop Color="#00000000" Offset="0.0" />
                 <GradientStop Color="#00000000" Offset="0.65" />


### PR DESCRIPTION
This PR improved the UI of Channel page header, Search panel, Pin panel, Member List panel, leave server context menu color and improve the navigation feel when navigate between servers. featuring:

- Search no-results UI with Discord-style messaging (4 languages)
- Auto-close sidebar on guild selection (narrow mode)
- Close buttons for Pins/UserList pages
- Search button reordering in header
- ShowSidebarButton glyph standardization (back arrow)
- SearchBox to AutoSuggestBox change

Tested on: Windows 11 Version 25H2 (OS Build 26220.7344) x64

So far, it's working in my device

Channel page header:
<img width="915" height="125" alt="image" src="https://github.com/user-attachments/assets/e264eab7-497d-459d-a903-4958393ce506" />
<img width="665" height="93" alt="image" src="https://github.com/user-attachments/assets/4bdbc0f3-63a4-4f9f-ba72-ab307406601c" />
<img width="665" height="175" alt="image" src="https://github.com/user-attachments/assets/72660fe8-c060-4f04-8dc2-402beb8f9bbc" />
<img width="633" height="115" alt="image" src="https://github.com/user-attachments/assets/900ea23b-340a-422b-ba2e-a0530add19fe" />

Search panel:
<img width="667" height="699" alt="image" src="https://github.com/user-attachments/assets/d54c5693-1ccb-4b62-bcf5-97e19ed52e30" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/2d961d92-eb33-42e2-adac-e508b53c9e37" />
<img width="667" height="699" alt="image" src="https://github.com/user-attachments/assets/aa664d93-aa07-4901-beb8-d8a014efdfa9" />

Pin panel:
<img width="667" height="816" alt="image" src="https://github.com/user-attachments/assets/a81b2492-4acb-4449-b139-e86d3a85e303" />

Member List panel:
<img width="667" height="816" alt="image" src="https://github.com/user-attachments/assets/f2623373-c35e-425b-b046-05098742150e" />

Leave Server:
<img width="316" height="483" alt="image" src="https://github.com/user-attachments/assets/cac243f3-4e79-400d-bfee-7b6bad66b424" />

Server Navigation:

https://github.com/user-attachments/assets/b80abd53-d4dd-4766-b3a4-7457bdef5297

