### PR TITLE
Enhanced Attachment Overlay

### DIFF
--- a/Unicord.Universal/Controls/ScaledContentControl.cs
+++ b/Unicord.Universal/Controls/ScaledContentControl.cs
@@ -35,6 +35,15 @@ namespace Unicord.Universal.Controls
         public static readonly DependencyProperty ForceSizeProperty =
             DependencyProperty.Register("ForceSize", typeof(bool), typeof(ScaledContentControl), new PropertyMetadata(false, OnWidthHeightPropertyChanged));
 
+        public bool UseFullscreen
+        {
+            get { return (bool)GetValue(UseFullscreenProperty); }
+            set { SetValue(UseFullscreenProperty, value); }
+        }
+
+        public static readonly DependencyProperty UseFullscreenProperty =
+            DependencyProperty.Register("UseFullscreen", typeof(bool), typeof(ScaledContentControl), new PropertyMetadata(false, OnWidthHeightPropertyChanged));
+
         private static void OnWidthHeightPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var control = (ScaledContentControl)d;
@@ -58,19 +67,49 @@ namespace Unicord.Universal.Controls
             double width = TargetWidth;
             double height = TargetHeight;
 
-            if (double.IsNaN(width) || double.IsNaN(height))
+            if (double.IsNaN(width) || double.IsNaN(height) || width <= 0 || height <= 0)
                 return base.MeasureOverride(constraint);
 
-            var maxWidth = Math.Min(root.Bounds.Width, Math.Min(MaxWidth, constraint.Width));
-            var maxHeight = Math.Min(root.Bounds.Height - 32, Math.Min(MaxHeight, constraint.Height));
+            var horizontalMargin = UseFullscreen ? 0 : 80;
+            var verticalMargin = UseFullscreen ? 0 : 160;
 
-            Drawing.ScaleProportions(ref width, ref height, maxWidth, maxHeight);
-            Drawing.ScaleProportions(ref width, ref height, Math.Min(constraint.Width, maxWidth), Math.Min(constraint.Height, maxHeight));
+            var maxWidth = Math.Min(root.Bounds.Width - horizontalMargin, Math.Min(MaxWidth, constraint.Width));
+            var maxHeight = Math.Min(root.Bounds.Height - verticalMargin, Math.Min(MaxHeight, constraint.Height));
+
+            if (UseFullscreen)
+            {
+                // Scale to cover the available area (fill both width and height) so panning can traverse full image
+                var scaleX = maxWidth / width;
+                var scaleY = maxHeight / height;
+                var scale = Math.Max(scaleX, scaleY);
+
+                // Apply scale
+                width = width * scale;
+                height = height * scale;
+            }
+            else
+            {
+                // Normal mode: Fit within maxWidth/maxHeight (contain)
+                // only scale down if the image is larger than the available space
+                if (width > maxWidth || height > maxHeight)
+                {
+                    var scaleX = maxWidth / width;
+                    var scaleY = maxHeight / height;
+                    var scale = Math.Min(scaleX, scaleY);
+                    width *= scale;
+                    height *= scale;
+                }
+            }
 
             if (ForceSize && Content is FrameworkElement element)
             {
                 element.Width = width;
                 element.Height = height;
+            }
+
+            if (Content is UIElement child)
+            {
+                child.Measure(new Size(width, height));
             }
 
             return new Size(width, height);

--- a/Unicord.Universal/Models/ViewModelbase.cs
+++ b/Unicord.Universal/Models/ViewModelbase.cs
@@ -14,11 +14,14 @@ namespace Unicord.Universal.Models
 
         public ViewModelBase(ViewModelBase parent = null)
         {
+            Parent = parent;
             discord = DiscordManager.Discord; // capture the discord client
             syncContext = parent?.syncContext ?? SynchronizationContext.Current;
             Debug.Assert(discord != null);
             Debug.Assert(syncContext != null);
         }
+
+        public ViewModelBase Parent { get; }
 
         public event PropertyChangedEventHandler PropertyChanged;
 

--- a/Unicord.Universal/Pages/Overlay/AttachmentOverlayPage.xaml
+++ b/Unicord.Universal/Pages/Overlay/AttachmentOverlayPage.xaml
@@ -1,17 +1,18 @@
 ﻿<Page
-    x:Class="Unicord.Universal.Pages.Overlay.AttachmentOverlayPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Unicord.Universal.Pages.Overlay"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:lib="using:Microsoft.UI.Xaml.Controls" 
-    xmlns:controls="using:Unicord.Universal.Controls" 
-    xmlns:media="using:Microsoft.Toolkit.Uwp.UI.Media" 
-    xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls" 
-    xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
-    xmlns:w1709="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 5)"
-    mc:Ignorable="d">
+x:Class="Unicord.Universal.Pages.Overlay.AttachmentOverlayPage"
+xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+xmlns:local="using:Unicord.Universal.Pages.Overlay"
+xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+xmlns:lib="using:Microsoft.UI.Xaml.Controls" 
+xmlns:controls="using:Unicord.Universal.Controls" 
+xmlns:media="using:Microsoft.Toolkit.Uwp.UI.Media" 
+xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls" 
+xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
+xmlns:w1709="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 5)"
+RequestedTheme="Dark"
+mc:Ignorable="d">
     <Page.Resources>
         <ui:AttachedDropShadow x:Key="ErrorShadow" CastTo="{x:Bind background}" BlurRadius="16" Opacity="1" Color="Black"/>
     </Page.Resources>

--- a/Unicord.Universal/Pages/Overlay/AttachmentOverlayPage.xaml
+++ b/Unicord.Universal/Pages/Overlay/AttachmentOverlayPage.xaml
@@ -18,35 +18,43 @@
 
     <Grid x:Name="contentContainer">
         <Border x:Name="background"
-                Tapped="contentContainer_Tapped"
-                Background="Transparent"/>
+            Tapped="contentContainer_Tapped"
+            Background="#B8000000"/>
 
         <Grid>
-            <ScrollViewer MinZoomFactor="1" 
+            <ScrollViewer x:Name="imageScrollViewer"
+                          MinZoomFactor="1" 
+                          MaxZoomFactor="10"
                           IsVerticalRailEnabled="False"
-                          VerticalScrollBarVisibility="Auto"
-                          VerticalScrollMode="Enabled"
+                          VerticalScrollBarVisibility="Hidden"
+                         VerticalScrollMode="Auto"
                           IsHorizontalRailEnabled="False"
-                          HorizontalScrollBarVisibility="Auto"
-                          HorizontalScrollMode="Enabled" 
+                          HorizontalScrollBarVisibility="Hidden"
+                         HorizontalScrollMode="Auto" 
                           HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch"
-                          HorizontalContentAlignment="Stretch"
-                          VerticalContentAlignment="Stretch"
-                          ZoomMode="Enabled"
-                          Tapped="contentContainer_Tapped">
+                         ZoomMode="Enabled"
+                          Tapped="contentContainer_Tapped"
+                          PointerPressed="imageScrollViewer_PointerPressed"
+                          PointerMoved="imageScrollViewer_PointerMoved"
+                          PointerReleased="imageScrollViewer_PointerReleased"
+                          PointerCanceled="imageScrollViewer_PointerReleased">
 
-                <controls:ScaledContentControl x:Name="scaledControl" MaxWidth="Infinity" MaxHeight="Infinity">
-                    <Image x:Name="attachmentImage"
-                           Tapped="attachmentImage_Tapped">
-                        <Image.Source>
-                            <BitmapImage x:Name="AttachmentSource" 
-                                         DownloadProgress="AttachmentSource_DownloadProgress" 
-                                         ImageOpened="AttachmentSource_ImageOpened"
-                                         ImageFailed="AttachmentSource_ImageFailed"/>
-                        </Image.Source>
-                    </Image>
-                </controls:ScaledContentControl>
+                <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <controls:ScaledContentControl x:Name="scaledControl" 
+                                                   ForceSize="True" 
+                                                   MaxWidth="Infinity" 
+                                                   MaxHeight="Infinity">
+                        <Image x:Name="attachmentImage" Tapped="attachmentImage_Tapped" DoubleTapped="attachmentImage_DoubleTapped">
+                            <Image.Source>
+                                <BitmapImage x:Name="AttachmentSource" 
+                                             DownloadProgress="AttachmentSource_DownloadProgress" 
+                                             ImageOpened="AttachmentSource_ImageOpened"
+                                             ImageFailed="AttachmentSource_ImageFailed"/>
+                            </Image.Source>
+                        </Image>
+                    </controls:ScaledContentControl>
+                </Grid>
             </ScrollViewer>
 
             <Grid x:Name="contentContainerOverlay" 
@@ -65,14 +73,98 @@
                         &#xE783;
                 </TextBlock>
             </Grid>
+
+            <lib:InfoBar x:Name="successInfoBar" 
+                         Severity="Success"
+                         IsOpen="False"
+                         HorizontalAlignment="Center" 
+                         VerticalAlignment="Bottom" 
+                         Margin="16"
+                         MaxWidth="400"/>
         </Grid>
 
         <Grid Margin="8" VerticalAlignment="Top">
-            <Button Style="{ThemeResource IconButtonStyle}" Content="&#xE72B;" x:Name="backButton" Click="backButton_Click">
-                <w1709:Button.KeyboardAccelerators>
-                    <w1709:KeyboardAccelerator Key="Escape"/>
-                </w1709:Button.KeyboardAccelerators>
-            </Button>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+                <Button Style="{ThemeResource IconButtonStyle}" Content="&#xE72B;" x:Name="backButton" Click="backButton_Click">
+                    <w1709:Button.KeyboardAccelerators>
+                        <w1709:KeyboardAccelerator Key="Escape"/>
+                    </w1709:Button.KeyboardAccelerators>
+                </Button>
+                <Ellipse Width="32" Height="32" Margin="12,0,0,0" VerticalAlignment="Center">
+                    <Ellipse.Fill>
+                        <ImageBrush x:Name="avatarBrush" Stretch="UniformToFill"/>
+                    </Ellipse.Fill>
+                </Ellipse>
+                <StackPanel Margin="8,0,0,0" VerticalAlignment="Center">
+                    <TextBlock x:Name="senderNameText" FontWeight="SemiBold" Foreground="White" FontSize="14"/>
+                    <TextBlock x:Name="timestampText" Foreground="#CCCCCC" FontSize="12" Opacity="0.8"/>
+                </StackPanel>
+            </StackPanel>
+
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <ComboBox x:Name="zoomComboBox" IsEditable="True" Width="Auto" MinWidth="80" VerticalAlignment="Center" 
+                              SelectionChanged="ZoomComboBox_SelectionChanged" 
+                              TextSubmitted="ZoomComboBox_TextSubmitted"
+                              LostFocus="ZoomComboBox_LostFocus"
+                              KeyDown="ZoomComboBox_KeyDown"
+                              Margin="0,0,4,0">
+                        <ComboBoxItem Content="100%" Tag="1" IsSelected="True"/>
+                        <ComboBoxItem Content="200%" Tag="2"/>
+                        <ComboBoxItem Content="300%" Tag="3"/>
+                        <ComboBoxItem Content="400%" Tag="4"/>
+                        <ComboBoxItem Content="500%" Tag="5"/>
+                        <ComboBoxItem Content="600%" Tag="6"/>
+                        <ComboBoxItem Content="700%" Tag="7"/>
+                        <ComboBoxItem Content="800%" Tag="8"/>
+                        <ComboBoxItem Content="900%" Tag="9"/>
+                        <ComboBoxItem Content="1000%" Tag="10"/>
+                    </ComboBox>
+                        <Button x:Uid="AttachmentOverlay_ZoomModeButton" x:Name="zoomModeButton" Style="{ThemeResource IconButtonStyle}" Click="ZoomModeButton_Click">
+                            <Grid Width="16" Height="16">
+                                <TextBlock x:Name="zoomBackIcon" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="16" Text="&#xE9A6;" HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="1"/>
+                                <TextBlock x:Name="zoomFrontIcon" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="16" Text="&#xE915;" HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="1"/>
+                            </Grid>
+                        </Button>
+                    <Button x:Uid="AttachmentOverlay_ZoomInButton" x:Name="zoomInButton" Style="{ThemeResource IconButtonStyle}" Content="&#xE8A3;" Click="ZoomIn_Click" Margin="4,0,0,0" />
+                    <Button x:Uid="AttachmentOverlay_ZoomOutButton" x:Name="zoomOutButton" Style="{ThemeResource IconButtonStyle}" Content="&#xE71F;" Click="ZoomOut_Click" Margin="4,0,0,0" />
+                    <Button x:Uid="AttachmentOverlay_MoreButton" x:Name="zoomMoreButton" Style="{ThemeResource IconButtonStyle}" Content="&#xE712;" Margin="4,0,0,0">
+                        <Button.Flyout>
+                            <MenuFlyout>
+                                <MenuFlyoutItem x:Uid="AttachmentOverlay_SaveAsMenuItem" Click="SaveAs_Click">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE74E;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Uid="AttachmentOverlay_ShareMenuItem" Click="Share_Click">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE72D;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Uid="AttachmentOverlay_OpenInBrowserMenuItem" Click="OpenInBrowser_Click">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE8A7;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
+                                <MenuFlyoutSeparator />
+                                <MenuFlyoutItem x:Uid="AttachmentOverlay_CopyImagesMenuItem" Click="CopyImages_Click">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE8C8;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Uid="AttachmentOverlay_CopyLinkMenuItem" Click="CopyLink_Click">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xE71B;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Uid="AttachmentOverlay_CopyAttachmentIdMenuItem" Click="CopyAttachmentId_Click">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xEC7A;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
+                            </MenuFlyout>
+                        </Button.Flyout>
+                    </Button>
+            </StackPanel>
         </Grid>
     </Grid>
 </Page>

--- a/Unicord.Universal/Pages/Overlay/AttachmentOverlayPage.xaml
+++ b/Unicord.Universal/Pages/Overlay/AttachmentOverlayPage.xaml
@@ -46,6 +46,36 @@
                                                    MaxWidth="Infinity" 
                                                    MaxHeight="Infinity">
                         <Image x:Name="attachmentImage" Tapped="attachmentImage_Tapped" DoubleTapped="attachmentImage_DoubleTapped">
+                            <Image.ContextFlyout>
+                                <MenuFlyout>
+                                    <MenuFlyoutItem x:Uid="AttachmentOverlay_CopyImagesMenuItem" Click="CopyImages_Click">
+                                        <MenuFlyoutItem.Icon>
+                                            <FontIcon Glyph="&#xE8C8;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                        </MenuFlyoutItem.Icon>
+                                    </MenuFlyoutItem>
+                                    <MenuFlyoutItem x:Uid="AttachmentOverlay_SaveAsMenuItem" Click="SaveAs_Click">
+                                        <MenuFlyoutItem.Icon>
+                                            <FontIcon Glyph="&#xE74E;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                        </MenuFlyoutItem.Icon>
+                                    </MenuFlyoutItem>
+                                    <MenuFlyoutItem x:Uid="AttachmentOverlay_ShareMenuItem" Click="Share_Click">
+                                        <MenuFlyoutItem.Icon>
+                                            <FontIcon Glyph="&#xE72D;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                        </MenuFlyoutItem.Icon>
+                                    </MenuFlyoutItem>
+                                    <MenuFlyoutSeparator />
+                                    <MenuFlyoutItem x:Uid="AttachmentOverlay_CopyLinkMenuItem" Click="CopyLink_Click">
+                                        <MenuFlyoutItem.Icon>
+                                            <FontIcon Glyph="&#xE71B;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                        </MenuFlyoutItem.Icon>
+                                    </MenuFlyoutItem>
+                                    <MenuFlyoutItem x:Uid="AttachmentOverlay_OpenInBrowserMenuItem" Click="OpenInBrowser_Click">
+                                        <MenuFlyoutItem.Icon>
+                                            <FontIcon Glyph="&#xE8A7;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                        </MenuFlyoutItem.Icon>
+                                    </MenuFlyoutItem>
+                                </MenuFlyout>
+                            </Image.ContextFlyout>
                             <Image.Source>
                                 <BitmapImage x:Name="AttachmentSource" 
                                              DownloadProgress="AttachmentSource_DownloadProgress" 

--- a/Unicord.Universal/Pages/Overlay/AttachmentOverlayPage.xaml.cs
+++ b/Unicord.Universal/Pages/Overlay/AttachmentOverlayPage.xaml.cs
@@ -1,20 +1,41 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
 using Unicord.Universal.Models.Messages;
 using Unicord.Universal.Services;
+using Unicord.Universal.Converters;
 using Windows.Foundation;
+using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Navigation;
+using Windows.System;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.ApplicationModel.Resources;
+using Windows.Storage;
+using Windows.Storage.Streams;
 
 namespace Unicord.Universal.Pages.Overlay
 {
     public sealed partial class AttachmentOverlayPage : Page, IOverlay
     {
+        private bool _isZoomMode;
+        private bool _isPanning;
+        private Point _lastPointerPosition;
+        private MessageViewModel _messageViewModel;
+        private ulong _attachmentId;
+        private Uri _currentAttachmentUri;
+        private string _originalFileName;
+
         public AttachmentOverlayPage()
         {
             this.InitializeComponent();
+            UpdateZoomButtonVisual();
+            DataTransferManager.GetForCurrentView().DataRequested += OnDataRequested;
         }
 
         public Size PreferredSize { get; }
@@ -29,21 +50,42 @@ namespace Unicord.Universal.Pages.Overlay
             {
                 scaledControl.TargetWidth = attachment.NaturalWidth;
                 scaledControl.TargetHeight = attachment.NaturalHeight;
-                attachmentImage.MaxWidth = attachment.NaturalWidth;
-                attachmentImage.MaxHeight = attachment.NaturalHeight;
 
                 AttachmentSource.UriSource = new Uri(attachment.ProxyUrl);
+                _currentAttachmentUri = new Uri(attachment.ProxyUrl);
+                
+                _messageViewModel = attachment.Parent as MessageViewModel;
+                // Access the attachment ID through reflection since it's not exposed as a public property
+                var attachmentType = attachment.GetType();
+                var attachmentField = attachmentType.GetField("_attachment", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                if (attachmentField?.GetValue(attachment) is DSharpPlus.Entities.DiscordAttachment discordAttachment)
+                {
+                    _attachmentId = discordAttachment.Id;
+                    _originalFileName = discordAttachment.FileName;
+                }
+                UpdateSenderInfo();
             }
 
             if (e.Parameter is EmbedImageViewModel thumbnail)
             {
                 scaledControl.TargetWidth = thumbnail.NaturalWidth;
                 scaledControl.TargetHeight = thumbnail.NaturalHeight;
-                attachmentImage.MaxWidth = thumbnail.NaturalWidth;
-                attachmentImage.MaxHeight = thumbnail.NaturalHeight;
 
                 AttachmentSource.UriSource = new Uri(thumbnail.Url);
+                _currentAttachmentUri = new Uri(thumbnail.Url);
+                
+                var embedViewModel = thumbnail.Parent as EmbedViewModel;
+                _messageViewModel = embedViewModel?.Parent as MessageViewModel;
+                _attachmentId = 0; // Embed images don't have attachment IDs
+                UpdateSenderInfo();
             }
+
+            // Always monitor view changes so pinch/scroll can dynamically toggle zoom mode
+            imageScrollViewer.ViewChanged -= ImageScrollViewer_ViewChanged;
+            imageScrollViewer.ViewChanged += ImageScrollViewer_ViewChanged;
+            
+            // Initialize zoom combobox
+            UpdateZoomComboBox();
         }
 
         private void AttachmentSource_DownloadProgress(object sender, DownloadProgressEventArgs e)
@@ -75,6 +117,588 @@ namespace Unicord.Universal.Pages.Overlay
         private void attachmentImage_Tapped(object sender, TappedRoutedEventArgs e)
         {
             e.Handled = true;
+        }
+
+        private void attachmentImage_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
+        {
+            e.Handled = true;
+
+            // If currently not in zoom mode, zoom into the tapped point.
+            if (!_isZoomMode)
+            {
+                // Compute the same target zoom used by the toggle (cover * 1.5)
+                var w = scaledControl.TargetWidth;
+                var h = scaledControl.TargetHeight;
+                var bounds = Window.Current.Bounds;
+                var winW = bounds.Width;
+                var winH = bounds.Height;
+
+                var mw_n = winW - 80;
+                var mh_n = winH - 160;
+                var s_c = Math.Min(1.0, Math.Min(mw_n / w, mh_n / h));
+                var s_v = Math.Max(winW / w, winH / h);
+                var targetZoom = (float)((s_v / s_c) * 1.5);
+
+                // Get pointer position relative to the scaled content
+                var pointer = e.GetPosition(scaledControl);
+
+                // Calculate target offsets so the pointer stays centered after zoom
+                var targetWidth = scaledControl.ActualWidth * targetZoom;
+                var targetHeight = scaledControl.ActualHeight * targetZoom;
+                var centerX = Math.Max(0, pointer.X * targetZoom - imageScrollViewer.ViewportWidth / 2);
+                var centerY = Math.Max(0, pointer.Y * targetZoom - imageScrollViewer.ViewportHeight / 2);
+
+                // Clamp to scrollable area
+                centerX = Math.Min(centerX, Math.Max(0, targetWidth - imageScrollViewer.ViewportWidth));
+                centerY = Math.Min(centerY, Math.Max(0, targetHeight - imageScrollViewer.ViewportHeight));
+
+                // Enter zoom mode state
+                _isZoomMode = true;
+                UpdateZoomButtonVisual();
+                background.Background = new SolidColorBrush(Color.FromArgb(0xB8, 0x00, 0x00, 0x00));
+
+                // Ensure we monitor view changes and enable zoom
+                EnsureZoomEnabled();
+
+                imageScrollViewer.ChangeView(centerX, centerY, targetZoom, false);
+            }
+            else
+            {
+                // Exit zoom mode
+                _isZoomMode = false;
+                UpdateZoomButtonVisual();
+
+                // Animate back to fit
+                imageScrollViewer.ChangeView(0, 0, 1.0f, false);
+            }
+        }
+
+        private void ZoomIn_Click(object sender, RoutedEventArgs e)
+        {
+            var current = imageScrollViewer.ZoomFactor;
+            var step = 1.25f;
+            var target = Math.Min(imageScrollViewer.MaxZoomFactor, current * step);
+
+            // Calculate viewport center in content coordinates
+            var viewportW = imageScrollViewer.ViewportWidth;
+            var viewportH = imageScrollViewer.ViewportHeight;
+            var contentCenterX = imageScrollViewer.HorizontalOffset + viewportW / 2.0;
+            var contentCenterY = imageScrollViewer.VerticalOffset + viewportH / 2.0;
+
+            var ratio = target / current;
+
+            // Map center to new offset so center remains centered
+            var newCenterX = contentCenterX * ratio;
+            var newCenterY = contentCenterY * ratio;
+            var targetOffsetX = Math.Max(0, newCenterX - viewportW / 2.0);
+            var targetOffsetY = Math.Max(0, newCenterY - viewportH / 2.0);
+
+            // Clamp to max scrollable size
+            var contentWidth = scaledControl.ActualWidth * target;
+            var contentHeight = scaledControl.ActualHeight * target;
+            var maxOffsetX = Math.Max(0, contentWidth - viewportW);
+            var maxOffsetY = Math.Max(0, contentHeight - viewportH);
+            targetOffsetX = Math.Min(targetOffsetX, maxOffsetX);
+            targetOffsetY = Math.Min(targetOffsetY, maxOffsetY);
+
+            // If not in zoom mode, enter it
+            if (!_isZoomMode)
+            {
+                _isZoomMode = true;
+                UpdateZoomButtonVisual();
+                background.Background = new SolidColorBrush(Color.FromArgb(0xB8, 0x00, 0x00, 0x00));
+                EnsureZoomEnabled();
+            }
+
+            imageScrollViewer.ChangeView(targetOffsetX, targetOffsetY, target, false);
+        }
+
+        private void ZoomOut_Click(object sender, RoutedEventArgs e)
+        {
+            var current = imageScrollViewer.ZoomFactor;
+            var step = 1.25f;
+            var target = Math.Max(1.0f, current / step);
+
+            // Calculate viewport center in content coordinates
+            var viewportW = imageScrollViewer.ViewportWidth;
+            var viewportH = imageScrollViewer.ViewportHeight;
+            var contentCenterX = imageScrollViewer.HorizontalOffset + viewportW / 2.0;
+            var contentCenterY = imageScrollViewer.VerticalOffset + viewportH / 2.0;
+
+            var ratio = target / current;
+            var newCenterX = contentCenterX * ratio;
+            var newCenterY = contentCenterY * ratio;
+            var targetOffsetX = Math.Max(0, newCenterX - viewportW / 2.0);
+            var targetOffsetY = Math.Max(0, newCenterY - viewportH / 2.0);
+
+            var contentWidth = scaledControl.ActualWidth * target;
+            var contentHeight = scaledControl.ActualHeight * target;
+            var maxOffsetX = Math.Max(0, contentWidth - viewportW);
+            var maxOffsetY = Math.Max(0, contentHeight - viewportH);
+            targetOffsetX = Math.Min(targetOffsetX, maxOffsetX);
+            targetOffsetY = Math.Min(targetOffsetY, maxOffsetY);
+
+            imageScrollViewer.ChangeView(targetOffsetX, targetOffsetY, target, false);
+        }
+
+        private void imageScrollViewer_PointerPressed(object sender, PointerRoutedEventArgs e)
+        {
+            var properties = e.GetCurrentPoint(imageScrollViewer).Properties;
+            // allow panning when user has zoomed in or when zoom-mode was explicitly enabled
+            if (properties.IsLeftButtonPressed && (imageScrollViewer.ZoomFactor > 1.0 || _isZoomMode))
+            {
+                _isPanning = true;
+                _lastPointerPosition = e.GetCurrentPoint(imageScrollViewer).Position;
+                imageScrollViewer.CapturePointer(e.Pointer);
+            }
+        }
+
+        private void imageScrollViewer_PointerMoved(object sender, PointerRoutedEventArgs e)
+        {
+            var properties = e.GetCurrentPoint(imageScrollViewer).Properties;
+            
+            // Stop panning if left button is no longer pressed
+            if (_isPanning && !properties.IsLeftButtonPressed)
+            {
+                _isPanning = false;
+                return;
+            }
+            
+            if (_isPanning)
+            {
+                var currentPosition = e.GetCurrentPoint(imageScrollViewer).Position;
+                var deltaX = currentPosition.X - _lastPointerPosition.X;
+                var deltaY = currentPosition.Y - _lastPointerPosition.Y;
+
+                imageScrollViewer.ChangeView(imageScrollViewer.HorizontalOffset - deltaX, imageScrollViewer.VerticalOffset - deltaY, null, true);
+                _lastPointerPosition = currentPosition;
+            }
+        }
+
+        private void imageScrollViewer_PointerReleased(object sender, PointerRoutedEventArgs e)
+        {
+            if (_isPanning)
+            {
+                _isPanning = false;
+                imageScrollViewer.ReleasePointerCapture(e.Pointer);
+            }
+        }
+
+        private async void OpenInBrowser_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var uri = AttachmentSource?.UriSource;
+                if (uri != null)
+                {
+                    await Launcher.LaunchUriAsync(uri);
+                }
+            }
+            catch { /* ignore failures silently */ }
+        }
+
+        private async void SaveAs_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var uri = AttachmentSource?.UriSource;
+                if (uri != null)
+                {
+                    var savePicker = new Windows.Storage.Pickers.FileSavePicker();
+                    savePicker.SuggestedStartLocation = Windows.Storage.Pickers.PickerLocationId.PicturesLibrary;
+                    
+                    // Detect file extension from original filename
+                    string extension = ".png";
+                    string fileNameWithoutExt = "attachment";
+                    
+                    if (!string.IsNullOrEmpty(_originalFileName))
+                    {
+                        extension = System.IO.Path.GetExtension(_originalFileName).ToLowerInvariant();
+                        fileNameWithoutExt = System.IO.Path.GetFileNameWithoutExtension(_originalFileName);
+                        
+                        if (string.IsNullOrEmpty(extension))
+                            extension = ".png";
+                    }
+                    
+                    // Map extension to file type choice
+                    var fileTypeName = extension.TrimStart('.').ToUpperInvariant() + " Image";
+                    savePicker.FileTypeChoices.Add(fileTypeName, new List<string> { extension });
+                    
+                    // Add other common image formats as alternatives
+                    if (extension != ".png")
+                        savePicker.FileTypeChoices.Add("PNG Image", new List<string> { ".png" });
+                    if (extension != ".jpg" && extension != ".jpeg")
+                        savePicker.FileTypeChoices.Add("JPEG Image", new List<string> { ".jpg", ".jpeg" });
+                    if (extension != ".gif")
+                        savePicker.FileTypeChoices.Add("GIF Image", new List<string> { ".gif" });
+                    if (extension != ".webp")
+                        savePicker.FileTypeChoices.Add("WebP Image", new List<string> { ".webp" });
+                    
+                    savePicker.SuggestedFileName = fileNameWithoutExt;
+
+                    var file = await savePicker.PickSaveFileAsync();
+                    if (file != null)
+                    {
+                        try
+                        {
+                            using (var httpClient = new System.Net.Http.HttpClient())
+                            {
+                                var bytes = await httpClient.GetByteArrayAsync(uri);
+                                await Windows.Storage.FileIO.WriteBytesAsync(file, bytes);
+                            }
+                            
+                            // Show success banner
+                            ShowSuccessBanner();
+                        }
+                        catch { /* ignore download errors */ }
+                    }
+                }
+            }
+            catch { /* ignore failures silently */ }
+        }
+
+        private void Share_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                DataTransferManager.ShowShareUI();
+            }
+            catch { /* ignore failures silently */ }
+        }
+
+        private async void OnDataRequested(DataTransferManager sender, DataRequestedEventArgs args)
+        {
+            if (_currentAttachmentUri != null)
+            {
+                var deferral = args.Request.GetDeferral();
+                try
+                {
+                    var request = args.Request;
+                    
+                    // Download the image to a temporary file
+                    var tempFolder = ApplicationData.Current.TemporaryFolder;
+                    var fileName = Path.GetFileName(_currentAttachmentUri.LocalPath);
+                    if (string.IsNullOrEmpty(fileName) || fileName == "/")
+                    {
+                        fileName = "image.png";
+                    }
+                    
+                    var tempFile = await tempFolder.CreateFileAsync(fileName, CreationCollisionOption.ReplaceExisting);
+                    
+                    using (var client = new HttpClient())
+                    {
+                        var imageData = await client.GetByteArrayAsync(_currentAttachmentUri);
+                        await FileIO.WriteBytesAsync(tempFile, imageData);
+                    }
+                    
+                    // Share the file with thumbnail
+                    var storageItems = new List<IStorageItem> { tempFile };
+                    request.Data.SetStorageItems(storageItems);
+                    
+                    // Set thumbnail for preview
+                    var thumbnail = RandomAccessStreamReference.CreateFromFile(tempFile);
+                    request.Data.Properties.Thumbnail = thumbnail;
+                    
+                    request.Data.Properties.Title = fileName;
+                    request.Data.Properties.Description = "Image from Unicord";
+                }
+                catch { /* ignore share data request errors */ }
+                finally
+                {
+                    deferral.Complete();
+                }
+            }
+        }
+
+        private void CopyLink_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var uri = AttachmentSource?.UriSource;
+                if (uri != null)
+                {
+                    var dp = new DataPackage();
+                    dp.SetText(uri.ToString());
+                    Clipboard.SetContent(dp);
+                }
+            }
+            catch { /* ignore failures silently */ }
+        }
+
+        private void CopyImages_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var uri = AttachmentSource?.UriSource;
+                if (uri != null)
+                {
+                    var dp = new DataPackage();
+                    dp.RequestedOperation = DataPackageOperation.Copy;
+                    var ras = RandomAccessStreamReference.CreateFromUri(uri);
+                    dp.SetBitmap(ras);
+                    Clipboard.SetContent(dp);
+                }
+            }
+            catch { /* ignore failures silently */ }
+        }
+
+        private void CopyAttachmentId_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (_attachmentId != 0)
+                {
+                    var dp = new DataPackage();
+                    dp.SetText(_attachmentId.ToString());
+                    Clipboard.SetContent(dp);
+                }
+            }
+            catch { /* ignore failures silently */ }
+        }
+
+        private void ImageScrollViewer_ViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
+        {
+            // Update zoom combobox to show current zoom level
+            UpdateZoomComboBox();
+
+            // Ignore intermediate (in-progress) changes; act only when finalized
+            if (e.IsIntermediate)
+                return;
+
+            // If user manually zooms (pinch/ctrl+wheel) beyond 1.0 while toggle is off, enter zoom mode
+            if (!_isZoomMode && imageScrollViewer.ZoomFactor > 1.01)
+            {
+                _isZoomMode = true;
+                UpdateZoomButtonVisual();
+                EnsureZoomEnabled();
+                background.Background = new SolidColorBrush(Color.FromArgb(0xB8, 0x00, 0x00, 0x00));
+                return;
+            }
+
+            // If user manually zooms back to normal while in zoom mode, exit zoom mode (animate to center)
+            if (_isZoomMode && imageScrollViewer.ZoomFactor <= 1.01)
+            {
+                _isZoomMode = false;
+                UpdateZoomButtonVisual();
+
+                // Animate back to centered normal view; after animation completes this handler will be invoked again (final) and clean up
+                imageScrollViewer.ChangeView(0, 0, 1.0f, false);
+                return;
+            }
+
+            // When exiting zoom mode programmatically we animate back to 1.0f; once reached, clean up visuals
+            if (!_isZoomMode && Math.Abs(imageScrollViewer.ZoomFactor - 1.0) < 0.01)
+            {
+                background.Background = new SolidColorBrush(Color.FromArgb(0xB8, 0x00, 0x00, 0x00));
+            }
+        }
+
+        private void ZoomModeButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (!_isZoomMode)
+                EnterZoomMode();
+            else
+                ExitZoomMode();
+        }
+
+        private void EnsureZoomEnabled()
+        {
+            imageScrollViewer.ViewChanged -= ImageScrollViewer_ViewChanged;
+            imageScrollViewer.ViewChanged += ImageScrollViewer_ViewChanged;
+            imageScrollViewer.MaxZoomFactor = 10;
+            imageScrollViewer.ZoomMode = ZoomMode.Enabled;
+            imageScrollViewer.HorizontalScrollMode = ScrollMode.Auto;
+            imageScrollViewer.VerticalScrollMode = ScrollMode.Auto;
+        }
+
+        private void UpdateZoomButtonVisual()
+        {
+            if (zoomFrontIcon != null)
+                zoomFrontIcon.Visibility = _isZoomMode ? Visibility.Collapsed : Visibility.Visible;
+            if (zoomModeButton != null)
+            {
+                var tip = _isZoomMode ? "Zoom to fit" : "Zoom to actual size";
+                ToolTipService.SetToolTip(zoomModeButton, tip);
+            }
+        }
+
+        private void EnterZoomMode()
+        {
+            _isZoomMode = true;
+            UpdateZoomButtonVisual();
+            background.Background = new SolidColorBrush(Color.FromArgb(0xB8, 0x00, 0x00, 0x00));
+            EnsureZoomEnabled();
+
+            var w = scaledControl.TargetWidth;
+            var h = scaledControl.TargetHeight;
+            var bounds = Window.Current.Bounds;
+            var winW = bounds.Width;
+            var winH = bounds.Height;
+
+            var mw_n = winW - 80;
+            var mh_n = winH - 160;
+            var s_c = Math.Min(1.0, Math.Min(mw_n / w, mh_n / h));
+            var s_v = Math.Max(winW / w, winH / h);
+            var targetZoom = (float)((s_v / s_c) * 1.5);
+
+            var targetWidth = scaledControl.ActualWidth * targetZoom;
+            var targetHeight = scaledControl.ActualHeight * targetZoom;
+            var centerX = Math.Max(0, (targetWidth - imageScrollViewer.ViewportWidth) / 2);
+            var centerY = Math.Max(0, (targetHeight - imageScrollViewer.ViewportHeight) / 2);
+
+            imageScrollViewer.ChangeView(centerX, centerY, targetZoom, false);
+        }
+
+        private void ExitZoomMode()
+        {
+            _isPanning = false;
+            _isZoomMode = false;
+            UpdateZoomButtonVisual();
+
+            imageScrollViewer.ViewChanged -= ImageScrollViewer_ViewChanged;
+            imageScrollViewer.ViewChanged += ImageScrollViewer_ViewChanged;
+            imageScrollViewer.ChangeView(0, 0, 1.0f, false);
+        }
+
+        private void UpdateSenderInfo()
+        {
+            if (_messageViewModel != null && senderNameText != null && timestampText != null)
+            {
+                senderNameText.Text = _messageViewModel.Author?.DisplayName ?? "Unknown";
+                
+                var timestampStyle = (TimestampStyle)App.RoamingSettings.Read(Constants.TIMESTAMP_STYLE, (int)TimestampStyle.Absolute);
+                timestampText.Text = DateTimeConverter.Convert(timestampStyle, _messageViewModel.Timestamp.DateTime);
+                
+                if (avatarBrush != null && _messageViewModel.Author?.AvatarUrl != null)
+                {
+                    avatarBrush.ImageSource = new BitmapImage(new Uri(_messageViewModel.Author.AvatarUrl));
+                }
+            }
+        }
+
+        private void UpdateZoomComboBox()
+        {
+            if (zoomComboBox == null) return;
+
+            var currentZoom = imageScrollViewer.ZoomFactor;
+            var percentText = $"{Math.Round(currentZoom * 100)}%";
+            
+            // Simply update the text display without triggering events
+            zoomComboBox.SelectionChanged -= ZoomComboBox_SelectionChanged;
+            zoomComboBox.TextSubmitted -= ZoomComboBox_TextSubmitted;
+            
+            zoomComboBox.Text = percentText;
+            
+            zoomComboBox.SelectionChanged += ZoomComboBox_SelectionChanged;
+            zoomComboBox.TextSubmitted += ZoomComboBox_TextSubmitted;
+        }
+
+        private void ZoomComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (zoomComboBox.SelectedItem is ComboBoxItem item && item.Tag is string tagStr)
+            {
+                if (float.TryParse(tagStr, out var zoomLevel))
+                {
+                    SetZoomLevel(zoomLevel);
+                }
+            }
+        }
+
+        private void ZoomComboBox_TextSubmitted(ComboBox sender, ComboBoxTextSubmittedEventArgs args)
+        {
+            ApplyZoomFromText(args.Text);
+        }
+
+        private void ZoomComboBox_LostFocus(object sender, RoutedEventArgs e)
+        {
+            // Update display to show actual current zoom
+            UpdateZoomComboBox();
+        }
+
+        private void ZoomComboBox_KeyDown(object sender, Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
+        {
+            if (e.Key == Windows.System.VirtualKey.Enter)
+            {
+                ApplyZoomFromText(zoomComboBox.Text);
+                e.Handled = true;
+            }
+        }
+
+        private void ApplyZoomFromText(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                UpdateZoomComboBox();
+                return;
+            }
+
+            text = text.Trim().TrimEnd('%');
+            if (float.TryParse(text, out var percent) && percent >= 100 && percent <= 1000)
+            {
+                var zoomLevel = percent / 100f;
+                SetZoomLevel(zoomLevel);
+            }
+            else
+            {
+                UpdateZoomComboBox(); // Reset to current value if invalid
+            }
+        }
+
+        private void SetZoomLevel(float zoomLevel)
+        {
+            // Clamp to valid range
+            zoomLevel = Math.Clamp(zoomLevel, 0.1f, imageScrollViewer.MaxZoomFactor);
+
+            if (zoomLevel <= 1.0f)
+            {
+                // Zoom to fit - exit zoom mode
+                if (_isZoomMode)
+                {
+                    ExitZoomMode();
+                }
+                else
+                {
+                    imageScrollViewer.ChangeView(0, 0, 1.0f, false);
+                }
+            }
+            else
+            {
+                // Zoom in - enter zoom mode if not already
+                if (!_isZoomMode)
+                {
+                    _isZoomMode = true;
+                    UpdateZoomButtonVisual();
+                    background.Background = new SolidColorBrush(Color.FromArgb(0xB8, 0x00, 0x00, 0x00));
+                    EnsureZoomEnabled();
+                }
+                
+                // Zoom to center of image content (not viewport center)
+                var viewportW = imageScrollViewer.ViewportWidth;
+                var viewportH = imageScrollViewer.ViewportHeight;
+                
+                // Calculate image center position at target zoom
+                var contentWidth = scaledControl.ActualWidth * zoomLevel;
+                var contentHeight = scaledControl.ActualHeight * zoomLevel;
+                
+                // Center the image in the viewport
+                var targetOffsetX = Math.Max(0, (contentWidth - viewportW) / 2.0);
+                var targetOffsetY = Math.Max(0, (contentHeight - viewportH) / 2.0);
+                
+                imageScrollViewer.ChangeView(targetOffsetX, targetOffsetY, zoomLevel, false);
+            }
+        }
+
+        private async void ShowSuccessBanner()
+        {
+            if (successInfoBar == null) return;
+
+            var resourceLoader = ResourceLoader.GetForCurrentView();
+            successInfoBar.Message = resourceLoader.GetString("AttachmentOverlay_SaveSuccessMessage");
+            successInfoBar.IsOpen = true;
+            
+            // Auto-hide after 3 seconds
+            await System.Threading.Tasks.Task.Delay(3000);
+            successInfoBar.IsOpen = false;
         }
     }
 }

--- a/Unicord.Universal/Resources/en-GB/Resources.resw
+++ b/Unicord.Universal/Resources/en-GB/Resources.resw
@@ -159,4 +159,37 @@
   <data name="VerifySettingsDisplayReason" xml:space="preserve">
     <value>Verify your identity to open settings!</value>
   </data>
+  <data name="AttachmentOverlay_ZoomModeButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Toggle zoom mode</value>
+  </data>
+  <data name="AttachmentOverlay_ZoomInButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Zoom in</value>
+  </data>
+  <data name="AttachmentOverlay_ZoomOutButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Zoom out</value>
+  </data>
+  <data name="AttachmentOverlay_MoreButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>More</value>
+  </data>
+  <data name="AttachmentOverlay_SaveAsMenuItem.Text" xml:space="preserve">
+    <value>Save as</value>
+  </data>
+  <data name="AttachmentOverlay_ShareMenuItem.Text" xml:space="preserve">
+    <value>Share</value>
+  </data>
+  <data name="AttachmentOverlay_OpenInBrowserMenuItem.Text" xml:space="preserve">
+    <value>Open in browser</value>
+  </data>
+  <data name="AttachmentOverlay_CopyImagesMenuItem.Text" xml:space="preserve">
+    <value>Copy images</value>
+  </data>
+  <data name="AttachmentOverlay_CopyLinkMenuItem.Text" xml:space="preserve">
+    <value>Copy link</value>
+  </data>
+  <data name="AttachmentOverlay_CopyAttachmentIdMenuItem.Text" xml:space="preserve">
+    <value>Copy attachment ID</value>
+  </data>
+  <data name="AttachmentOverlay_SaveSuccessMessage" xml:space="preserve">
+    <value>File saved successfully</value>
+  </data>
 </root>

--- a/Unicord.Universal/Resources/en-US/Resources.resw
+++ b/Unicord.Universal/Resources/en-US/Resources.resw
@@ -159,4 +159,37 @@
   <data name="VerifySettingsDisplayReason" xml:space="preserve">
     <value>Verify your identity to open settings!</value>
   </data>
+  <data name="AttachmentOverlay_ZoomModeButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Toggle zoom mode</value>
+  </data>
+  <data name="AttachmentOverlay_ZoomInButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Zoom in</value>
+  </data>
+  <data name="AttachmentOverlay_ZoomOutButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Zoom out</value>
+  </data>
+  <data name="AttachmentOverlay_MoreButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>More</value>
+  </data>
+  <data name="AttachmentOverlay_SaveAsMenuItem.Text" xml:space="preserve">
+    <value>Save as</value>
+  </data>
+  <data name="AttachmentOverlay_ShareMenuItem.Text" xml:space="preserve">
+    <value>Share</value>
+  </data>
+  <data name="AttachmentOverlay_OpenInBrowserMenuItem.Text" xml:space="preserve">
+    <value>Open in browser</value>
+  </data>
+  <data name="AttachmentOverlay_CopyImagesMenuItem.Text" xml:space="preserve">
+    <value>Copy images</value>
+  </data>
+  <data name="AttachmentOverlay_CopyLinkMenuItem.Text" xml:space="preserve">
+    <value>Copy link</value>
+  </data>
+  <data name="AttachmentOverlay_CopyAttachmentIdMenuItem.Text" xml:space="preserve">
+    <value>Copy attachment ID</value>
+  </data>
+  <data name="AttachmentOverlay_SaveSuccessMessage" xml:space="preserve">
+    <value>File saved successfully</value>
+  </data>
 </root>

--- a/Unicord.Universal/Resources/fr/Resources.resw
+++ b/Unicord.Universal/Resources/fr/Resources.resw
@@ -159,4 +159,37 @@
   <data name="VerifySettingsDisplayReason" xml:space="preserve">
     <value>Vérifiez votre identité pour ouvrir les paramètres!</value>
   </data>
+  <data name="AttachmentOverlay_ZoomModeButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Basculer le mode zoom</value>
+  </data>
+  <data name="AttachmentOverlay_ZoomInButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Zoom avant</value>
+  </data>
+  <data name="AttachmentOverlay_ZoomOutButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Zoom arrière</value>
+  </data>
+  <data name="AttachmentOverlay_MoreButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Plus</value>
+  </data>
+  <data name="AttachmentOverlay_SaveAsMenuItem.Text" xml:space="preserve">
+    <value>Enregistrer sous</value>
+  </data>
+  <data name="AttachmentOverlay_ShareMenuItem.Text" xml:space="preserve">
+    <value>Partager</value>
+  </data>
+  <data name="AttachmentOverlay_OpenInBrowserMenuItem.Text" xml:space="preserve">
+    <value>Ouvrir dans le navigateur</value>
+  </data>
+  <data name="AttachmentOverlay_CopyImagesMenuItem.Text" xml:space="preserve">
+    <value>Copier les images</value>
+  </data>
+  <data name="AttachmentOverlay_CopyLinkMenuItem.Text" xml:space="preserve">
+    <value>Copier le lien</value>
+  </data>
+  <data name="AttachmentOverlay_CopyAttachmentIdMenuItem.Text" xml:space="preserve">
+    <value>Copier l'ID de la pièce jointe</value>
+  </data>
+  <data name="AttachmentOverlay_SaveSuccessMessage" xml:space="preserve">
+    <value>Fichier enregistré avec succès</value>
+  </data>
 </root>

--- a/Unicord.Universal/Resources/ja-JP/Resources.resw
+++ b/Unicord.Universal/Resources/ja-JP/Resources.resw
@@ -159,4 +159,37 @@
   <data name="VerifySettingsDisplayReason" xml:space="preserve">
     <value>設定を開くためには認証が必要です！</value>
   </data>
+  <data name="AttachmentOverlay_ZoomModeButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>ズームモードを切り替え</value>
+  </data>
+  <data name="AttachmentOverlay_ZoomInButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>拡大</value>
+  </data>
+  <data name="AttachmentOverlay_ZoomOutButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>縮小</value>
+  </data>
+  <data name="AttachmentOverlay_MoreButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>その他</value>
+  </data>
+  <data name="AttachmentOverlay_SaveAsMenuItem.Text" xml:space="preserve">
+    <value>名前を付けて保存</value>
+  </data>
+  <data name="AttachmentOverlay_ShareMenuItem.Text" xml:space="preserve">
+    <value>共有</value>
+  </data>
+  <data name="AttachmentOverlay_OpenInBrowserMenuItem.Text" xml:space="preserve">
+    <value>ブラウザで開く</value>
+  </data>
+  <data name="AttachmentOverlay_CopyImagesMenuItem.Text" xml:space="preserve">
+    <value>画像をコピー</value>
+  </data>
+  <data name="AttachmentOverlay_CopyLinkMenuItem.Text" xml:space="preserve">
+    <value>リンクをコピー</value>
+  </data>
+  <data name="AttachmentOverlay_CopyAttachmentIdMenuItem.Text" xml:space="preserve">
+    <value>添付ファイルIDをコピー</value>
+  </data>
+  <data name="AttachmentOverlay_SaveSuccessMessage" xml:space="preserve">
+    <value>ファイルが正常に保存されました</value>
+  </data>
 </root>

--- a/Unicord.Universal/Resources/ru-RU/Resources.resw
+++ b/Unicord.Universal/Resources/ru-RU/Resources.resw
@@ -159,4 +159,37 @@
 <data name="VerifySettingsDisplayReason" xml:space="preserve">
   <value>Подтвердите свою личность, чтобы открыть настройки!</value>
 </data>
+<data name="AttachmentOverlay_ZoomModeButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+  <value>Переключить режим масштабирования</value>
+</data>
+<data name="AttachmentOverlay_ZoomInButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+  <value>Увеличить</value>
+</data>
+<data name="AttachmentOverlay_ZoomOutButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+  <value>Уменьшить</value>
+</data>
+<data name="AttachmentOverlay_MoreButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+  <value>Дополнительно</value>
+</data>
+<data name="AttachmentOverlay_SaveAsMenuItem.Text" xml:space="preserve">
+  <value>Сохранить как</value>
+</data>
+<data name="AttachmentOverlay_ShareMenuItem.Text" xml:space="preserve">
+  <value>Поделиться</value>
+</data>
+<data name="AttachmentOverlay_OpenInBrowserMenuItem.Text" xml:space="preserve">
+  <value>Открыть в браузере</value>
+</data>
+<data name="AttachmentOverlay_CopyImagesMenuItem.Text" xml:space="preserve">
+  <value>Копировать изображения</value>
+</data>
+<data name="AttachmentOverlay_CopyLinkMenuItem.Text" xml:space="preserve">
+  <value>Копировать ссылку</value>
+</data>
+<data name="AttachmentOverlay_CopyAttachmentIdMenuItem.Text" xml:space="preserve">
+  <value>Копировать ID вложения</value>
+</data>
+<data name="AttachmentOverlay_SaveSuccessMessage" xml:space="preserve">
+  <value>Файл успешно сохранён</value>
+</data>
 </root>

--- a/Unicord.Universal/Themes/Styles/SunValley.xaml
+++ b/Unicord.Universal/Themes/Styles/SunValley.xaml
@@ -135,12 +135,12 @@
                     <StaticResource x:Key="ImageEmbed_Background" ResourceKey="CardBackgroundFillColorSecondaryBrush"/>
                     <StaticResource x:Key="ImageEmbed_BorderBrush" ResourceKey="CardStrokeColorDefaultBrush"/>
                     <Thickness x:Key="ImageEmbed_BorderThickness">1</Thickness>
-                    <CornerRadius x:Key="ImageEmbed_CornerRadius">2</CornerRadius>
+                    <CornerRadius x:Key="ImageEmbed_CornerRadius">8</CornerRadius>
 
                     <StaticResource x:Key="Attachment_Background" ResourceKey="CardBackgroundFillColorDefaultBrush"/>
                     <StaticResource x:Key="Attachment_BorderBrush" ResourceKey="CardStrokeColorDefaultBrush"/>
                     <Thickness x:Key="Attachment_BorderThickness">1</Thickness>
-                    <CornerRadius x:Key="Attachment_CornerRadius">4</CornerRadius>
+                    <CornerRadius x:Key="Attachment_CornerRadius">8</CornerRadius>
 
                     <StaticResource x:Key="AudioMediaTransportControls_ControlPanel_Background" ResourceKey="CardBackgroundFillColorDefaultBrush"/>
                     <StaticResource x:Key="AudioMediaTransportControls_ControlPanel_BorderBrush" ResourceKey="CardStrokeColorDefaultBrush"/>


### PR DESCRIPTION
This PR enhances the attachment overlay (image viewer) zoom controls, date display, and action menu from latest discord interface. Features:

- zoom controls with toggle mode, in/out buttons, and editable ComboBox (100%-1000%)
- Gestures including double-tap zoom, pinch-to-zoom, and drag-to-pan
- Sender metadata display showing avatar, name, and timestamp with user's format preference
- Action menu flyout with Save as, Windows Share function, Open in browser, Copy images/link/ID
- Success notification using InfoBar with auto-hide (3 seconds)
- Rounded corners for attachment images in Sun Valley theme (8px)

Tested on: Windows 11 Version 25H2 (OS Build 26220.7523) x64

Preview:
- zoom controls with toggle mode, in/out buttons, and editable ComboBox (100%-1000%)
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/486e1622-35e7-45b7-8749-8d8b73ea44b3" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/3bfb8e58-c599-40ab-a7ad-42bb06160a73" />

- Action menu flyout
<img width="357" height="359" alt="image" src="https://github.com/user-attachments/assets/0327fcb4-540c-41e0-b7c2-9dcdd3149d7b" />

- Rounded corners for attachment images in Sun Valley theme (8px)
<img width="610" height="611" alt="image" src="https://github.com/user-attachments/assets/0a7f5501-ed52-4da2-aa7d-849ef2b519a0" />