### PR TITLE
Improved Settings Page

### DIFF
--- a/Unicord.Universal/Controls/Settings/SettingsBlockControl.xaml
+++ b/Unicord.Universal/Controls/Settings/SettingsBlockControl.xaml
@@ -49,7 +49,7 @@
         <!-- Expander -->
         <Grid x:Name="ExpanderPreGrid" x:Load="{x:Bind ExpandableContent, Mode=OneWay, Converter={StaticResource NullToFalseConverter}}">
             <Grid x:Name="ExpanderGrid" x:Load="{x:Bind IsClickable, Mode=OneWay, Converter={StaticResource InverseBooleanConverter}}">
-                <muxc:Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Expanding="Expander_Expanding" Collapsed="Expander_Collapsed">
+                <muxc:Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Expanding="Expander_Expanding" Collapsed="Expander_Collapsed" IsExpanded="{x:Bind IsExpanded, Mode=TwoWay}">
                     <muxc:Expander.Header>
                         <local:SettingsDisplayControl Icon="{x:Bind Icon, Mode=OneWay}" 
                                                       Margin="0,16"
@@ -59,7 +59,7 @@
                                                       SettingsActionableElement="{x:Bind SettingsActionableElement, Mode=OneWay}"/>
                     </muxc:Expander.Header>
 
-                    <ContentPresenter Margin="-16" HorizontalAlignment="Stretch" Content="{x:Bind ExpandableContent, Mode=OneWay}" />
+                    <ContentPresenter Margin="0" HorizontalAlignment="Stretch" Content="{x:Bind ExpandableContent, Mode=OneWay}" />
                 </muxc:Expander>
             </Grid>
         </Grid>

--- a/Unicord.Universal/Controls/Settings/SettingsBlockControl.xaml.cs
+++ b/Unicord.Universal/Controls/Settings/SettingsBlockControl.xaml.cs
@@ -87,6 +87,19 @@ namespace SettingsControl
             set => SetValue(IsClickableProperty, value);
         }
 
+        public static readonly DependencyProperty IsExpandedProperty = DependencyProperty.Register(
+          "IsExpanded",
+          typeof(bool),
+          typeof(SettingsBlockControl),
+          new PropertyMetadata(false)
+        );
+
+        public bool IsExpanded
+        {
+            get => (bool)GetValue(IsExpandedProperty);
+            set => SetValue(IsExpandedProperty, value);
+        }
+
         //
         // Summary:
         //     Occurs when a button control is clicked.

--- a/Unicord.Universal/Controls/Settings/SettingsDisplayControl.xaml
+++ b/Unicord.Universal/Controls/Settings/SettingsDisplayControl.xaml
@@ -67,7 +67,6 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
             <TextBlock x:Name="TitleBlock"
@@ -75,16 +74,18 @@
                        Text="{x:Bind Title, Mode=OneWay}"
                        TextWrapping="Wrap"/>
 
-            <TextBlock x:Name="DescriptionBlock"
-                       x:Load="{x:Bind Description, Mode=OneWay, Converter={StaticResource StringNullOrWhiteSpaceToFalseConverter}}"
-                       Grid.Row="1"
-                       Style="{StaticResource TextBlockSettingDescriptionStyle}"
-                       Text="{x:Bind Description, Mode=OneWay}"/>
+            <StackPanel Grid.Row="1" Orientation="Vertical">
+                <TextBlock x:Name="DescriptionBlock"
+                           x:Load="{x:Bind Description, Mode=OneWay, Converter={StaticResource StringNullOrWhiteSpaceToFalseConverter}}"
+                           Style="{StaticResource TextBlockSettingDescriptionStyle}"
+                           Text="{x:Bind Description, Mode=OneWay}"/>
 
-            <ContentPresenter x:Name="AdditionalContentPanel"
-                              x:Load="{x:Bind AdditionalDescriptionContent, Mode=OneWay, Converter={StaticResource NullToFalseConverter}}"
-                              Grid.Row="2"
-                              Content="{x:Bind AdditionalDescriptionContent, Mode=OneWay}"/>
+                <ContentPresenter x:Name="AdditionalContentPanel"
+                                  x:Load="{x:Bind AdditionalDescriptionContent, Mode=OneWay, Converter={StaticResource NullToFalseConverter}}"
+                                  Margin="0,2,0,0"
+                                  HorizontalAlignment="Left"
+                                  Content="{x:Bind AdditionalDescriptionContent, Mode=OneWay}"/>
+            </StackPanel>
         </Grid>
 
         <ContentPresenter x:Name="ActionableElement"

--- a/Unicord.Universal/Models/Settings/AccountsSettingsModel.cs
+++ b/Unicord.Universal/Models/Settings/AccountsSettingsModel.cs
@@ -1,7 +1,12 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Messaging;
 using DSharpPlus.Entities;
 using DSharpPlus.Enums;
+using DSharpPlus.EventArgs;
+using Microsoft.Toolkit.Uwp.Helpers;
+using Unicord.Universal.Models.Messaging;
+using Unicord.Universal.Models.User;
 using Unicord.Universal.Pages.Settings;
 using Windows.ApplicationModel.Resources;
 using static Unicord.Constants;
@@ -10,9 +15,19 @@ namespace Unicord.Universal.Models
 {
     public class AccountsSettingsModel : ViewModelBase
     {
+        private static readonly bool _isWindows11 = SystemInformation.Instance.OperatingSystemVersion.Build >= 22000;
+        private static readonly ResourceLoader _resourceLoader = ResourceLoader.GetForViewIndependentUse("AccountsSettingsPage");
+
         public AccountsSettingsModel()
         {
             User = discord?.CurrentUser;
+
+            if (User != null)
+            {
+                UserPresence = new PresenceViewModel(User, this);
+                WeakReferenceMessenger.Default.Register<AccountsSettingsModel, DiscordEventMessage<PresenceUpdateEventArgs>>(this,
+                    (t, e) => t.OnPresenceUpdate(e.Event));
+            }
 
             var strings = ResourceLoader.GetForCurrentView(nameof(AccountsSettingsPage));
             _loading = strings.GetString("Loading");
@@ -50,6 +65,8 @@ namespace Unicord.Universal.Models
         private DiscordUser _user;
         private string _loading;
 
+        public PresenceViewModel UserPresence { get; }
+
         private int? _serverCount;
         private int? _channelCount;
         private int? _memberCount;
@@ -65,11 +82,30 @@ namespace Unicord.Universal.Models
             set => OnPropertySet(ref _user, value);
         }
 
+        private void OnPresenceUpdate(PresenceUpdateEventArgs e)
+        {
+            if (User == null || UserPresence == null || e.User.Id != User.Id)
+                return;
+
+            UserPresence.OnPresenceUpdated();
+        }
+
         public bool BackgroundNotifications
         {
             get => App.LocalSettings.Read(BACKGROUND_NOTIFICATIONS_FULL_TRUST, true);
             set => App.LocalSettings.Save(BACKGROUND_NOTIFICATIONS_FULL_TRUST, value);
         }
+
+        public string BackgroundNotificationIcon
+            => _isWindows11 ? "\uEA8F" : "\uE7E7";
+
+        public string BackgroundNotificationDescription
+            => _isWindows11
+                ? _resourceLoader.GetString("BackgroundNotificationsDescriptionWin11")
+                : _resourceLoader.GetString("BackgroundNotificationsDescriptionWin10");
+
+        public bool IsSyncContactsVisible
+            => !_isWindows11;
 
         public string ServerCountString => _serverCount == null ? _loading : $"{_serverCount:N0}";
         public string ChannelsCountString => _channelCount == null ? _loading : $"{_channelCount:N0}";

--- a/Unicord.Universal/Models/Settings/NotificationsSettingsModel.cs
+++ b/Unicord.Universal/Models/Settings/NotificationsSettingsModel.cs
@@ -1,4 +1,6 @@
-﻿using Windows.ApplicationModel;
+﻿using Microsoft.Toolkit.Uwp.Helpers;
+using Windows.ApplicationModel;
+using Windows.ApplicationModel.Resources;
 using Windows.Foundation.Metadata;
 using static Unicord.Constants;
 
@@ -7,6 +9,8 @@ namespace Unicord.Universal.Models
     public class NotificationsSettingsModel : ViewModelBase
     {
         private bool isPageEnabled = ApiInformation.IsApiContractPresent(typeof(FullTrustAppContract).FullName, 1);
+        private static readonly bool _isWindows11 = SystemInformation.Instance.OperatingSystemVersion.Build >= 22000;
+        private static readonly ResourceLoader _resourceLoader = ResourceLoader.GetForViewIndependentUse("NotificationsSettingsPage");
 
         public bool IsPageEnabled
         {
@@ -54,5 +58,18 @@ namespace Unicord.Universal.Models
             get => App.RoamingSettings.Read(ENABLE_LIVE_TILES, ENABLE_LIVE_TILES_DEFAULT);
             set => App.RoamingSettings.Save(ENABLE_LIVE_TILES, value);
         }
+
+        public string EnableNotificationsDescription
+            => _isWindows11 
+                ? _resourceLoader.GetString("EnableNotificationsDescriptionWin11")
+                : _resourceLoader.GetString("EnableNotificationsDescriptionWin10");
+
+        public string EnableDesktopNotificationsDescription
+            => _isWindows11
+                ? _resourceLoader.GetString("EnableDesktopNotificationsDescriptionWin11")
+                : _resourceLoader.GetString("EnableDesktopNotificationsDescriptionWin10");
+
+        public bool IsLiveTilesVisible
+            => !_isWindows11;
     }
 }

--- a/Unicord.Universal/Models/Settings/RootSettingsModel.cs
+++ b/Unicord.Universal/Models/Settings/RootSettingsModel.cs
@@ -8,6 +8,8 @@ namespace Unicord.Universal.Models
 {
     public class RootSettingsModel : ViewModelBase
     {
+        private static readonly bool _isWindows11 = SystemInformation.Instance.OperatingSystemVersion.Build >= 22000;
+
         public DiscordUser CurrentUser =>
             discord.CurrentUser;
 
@@ -30,8 +32,11 @@ namespace Unicord.Universal.Models
                     gitSha = "-" + attribute.InformationalVersion.Substring(idx + 1, 7);
                 }
 
-                return $"v{Package.Current.Id.Version.ToFormattedString(3)}{gitSha}";
+                return $"{Package.Current.Id.Version.ToFormattedString(3)}{gitSha}";
             }
         }
+
+        public string NotificationIconGlyph
+            => _isWindows11 ? "\uEA8F" : "\uE91C";
     }
 }

--- a/Unicord.Universal/Models/Settings/RootSettingsModel.cs
+++ b/Unicord.Universal/Models/Settings/RootSettingsModel.cs
@@ -19,6 +19,12 @@ namespace Unicord.Universal.Models
         public string AccountDisplayName =>
             discord.CurrentUser.Username;
 
+        public string ProfileDisplayName =>
+            discord.CurrentUser?.GlobalName ?? discord.CurrentUser?.Username;
+
+        public string ProfileAvatarUrl =>
+            discord.CurrentUser?.GetAvatarUrl(256);
+
         public string DisplayVersion
         {
             get

--- a/Unicord.Universal/Pages/Settings/AboutSettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/AboutSettingsPage.xaml
@@ -5,153 +5,170 @@
     xmlns:local="using:Unicord.Universal.Pages.Settings"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:settings="using:SettingsControl"
     mc:Ignorable="d">
 
-    <Grid Margin="0,8">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
-        <Image HorizontalAlignment="Left"
-               Source="{ThemeResource DiscordWordMark}"
-               MaxWidth="400"
-               Margin="-6,-16,0,0"/>
-        <!--<TextBlock x:Uid="AppDisplayNameText" Grid.Row="1" Style="{ThemeResource TitleTextBlockStyle}" />-->
-        <TextBlock x:Uid="AppDisplayDescriptionText" 
-                   Grid.Row="2" 
-                   TextWrapping="WrapWholeWords"                    
-                   Style="{ThemeResource TitleTextBlockStyle}"
-                   FontFamily="Segoe UI Variable Display" />
-        <TextBlock Text="{Binding DisplayVersion}"
-                   Grid.Row="3" 
-                   TextWrapping="WrapWholeWords"                    
-                   Style="{ThemeResource SubtitleTextBlockStyle}"
-                   FontFamily="Segoe UI Variable Display"/>
+    <muxc:Expander Margin="0,8" IsExpanded="True" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" VerticalAlignment="Top">
+        <muxc:Expander.Header>
+            <Grid HorizontalAlignment="Stretch" Padding="0,12">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                
+                <StackPanel Orientation="Horizontal" Spacing="16" Grid.Column="0">
+                    <Image Source="{StaticResource DiscordClyde}" 
+                           Width="24" 
+                           Height="24"
+                           VerticalAlignment="Center"/>
+                    <StackPanel VerticalAlignment="Center">
+                        <TextBlock x:Uid="AppDisplayNameText"
+                                   Style="{ThemeResource BodyStrongTextBlockStyle}"/>
+                        <TextBlock x:Uid="AppDisplayDescriptionText"
+                                   Style="{ThemeResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   TextWrapping="NoWrap"/>
+                    </StackPanel>
+                </StackPanel>
+                
+                <TextBlock Text="{Binding DisplayVersion}"
+                           Grid.Column="1"
+                           VerticalAlignment="Center"
+                           Margin="12,0,0,0"
+                           IsTextSelectionEnabled="True"/>
+            </Grid>
+        </muxc:Expander.Header>
 
-        <StackPanel Grid.Row="4" Margin="0,8,0,0">
-            <TextBlock x:Uid="/AboutSettingsPage/AcknowledgementsText" Grid.Row="1" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,0,0,5" />
-            <RichTextBlock>
-                <Paragraph>
-                    <Bold>DSharpPlus</Bold>
-                    <Run>- A C# library for making bots using the Discord API.</Run>
-                </Paragraph>
-                <Paragraph>
-                    <Run>Copyright © 2015 Mike Santiago</Run>
-                    <LineBreak/>
-                    <Run>Copyright © 2016-2018 DSharpPlus Development Team</Run>
-                </Paragraph>
-                <Paragraph>Used under the
-                    <Hyperlink NavigateUri="https://github.com/DSharpPlus/DSharpPlus/blob/master/LICENSE">MIT licence</Hyperlink>
-                </Paragraph>
+        <StackPanel Margin="0,8,0,0">
+            <TextBlock x:Uid="AcknowledgementsText"
+                       Text="Acknowledgements"
+                       Margin="20,0,0,0" />
+            <RichTextBlock Margin="20,8,20,0">
+                    <Paragraph>
+                        <Bold>DSharpPlus</Bold>
+                        <Run>- A C# library for making bots using the Discord API.</Run>
+                    </Paragraph>
+                    <Paragraph>
+                        <Run>Copyright © 2015 Mike Santiago</Run>
+                        <LineBreak/>
+                        <Run>Copyright © 2016-2018 DSharpPlus Development Team</Run>
+                    </Paragraph>
+                    <Paragraph>Used under the
+                        <Hyperlink NavigateUri="https://github.com/DSharpPlus/DSharpPlus/blob/master/LICENSE">MIT licence</Hyperlink>
+                    </Paragraph>
 
-                <Paragraph/>
+                    <Paragraph/>
 
-                <Paragraph>
-                    <Bold>Windows Community Toolkit</Bold>
-                    <Run>- A collection of helper functions, custom controls, and app services.</Run>
-                </Paragraph>
-                <Paragraph>
-                    <Run>Copyright © .NET Foundation and Contributors</Run>
-                </Paragraph>
-                <Paragraph>Used under the
-                    <Hyperlink NavigateUri="https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/master/license.md">MIT licence</Hyperlink>
-                </Paragraph>
+                    <Paragraph>
+                        <Bold>Windows Community Toolkit</Bold>
+                        <Run>- A collection of helper functions, custom controls, and app services.</Run>
+                    </Paragraph>
+                    <Paragraph>
+                        <Run>Copyright © .NET Foundation and Contributors</Run>
+                    </Paragraph>
+                    <Paragraph>Used under the
+                        <Hyperlink NavigateUri="https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/master/license.md">MIT licence</Hyperlink>
+                    </Paragraph>
 
-                <Paragraph/>
+                    <Paragraph/>
 
-                <Paragraph>
-                    <Bold>ColorCode-Universal</Bold>
-                    <Run>- A port of ColorCode to .NET Standard.</Run>
-                </Paragraph>
-                <Paragraph>
-                    <Run>Copyright © Microsoft Corporation, William Bradley 2017</Run>
-                </Paragraph>
-                <Paragraph>Used under the
-                    <Hyperlink NavigateUri="https://github.com/WilliamABradley/ColorCode-Universal/blob/master/license.md">Microsoft Public License</Hyperlink>
-                </Paragraph>
+                    <Paragraph>
+                        <Bold>ColorCode-Universal</Bold>
+                        <Run>- A port of ColorCode to .NET Standard.</Run>
+                    </Paragraph>
+                    <Paragraph>
+                        <Run>Copyright © Microsoft Corporation, William Bradley 2017</Run>
+                    </Paragraph>
+                    <Paragraph>Used under the
+                        <Hyperlink NavigateUri="https://github.com/WilliamABradley/ColorCode-Universal/blob/master/license.md">Microsoft Public License</Hyperlink>
+                    </Paragraph>
 
-                <Paragraph/>
+                    <Paragraph/>
 
-                <Paragraph>
-                    <Bold>Newtonsoft.Json</Bold>
-                    <Run>- A popular high-performance JSON framework for .NET.</Run>
-                </Paragraph>
-                <Paragraph>
-                    <Run>Copyright © 2007 James Newton-King</Run>
-                </Paragraph>
-                <Paragraph>Used under the
-                    <Hyperlink NavigateUri="https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md">MIT licence</Hyperlink>
-                </Paragraph>
+                    <Paragraph>
+                        <Bold>Newtonsoft.Json</Bold>
+                        <Run>- A popular high-performance JSON framework for .NET.</Run>
+                    </Paragraph>
+                    <Paragraph>
+                        <Run>Copyright © 2007 James Newton-King</Run>
+                    </Paragraph>
+                    <Paragraph>Used under the
+                        <Hyperlink NavigateUri="https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md">MIT licence</Hyperlink>
+                    </Paragraph>
 
-                <Paragraph/>
+                    <Paragraph/>
 
-                <Paragraph>
-                    <Bold>libsodium</Bold>
-                    <Run>- A modern, portable, easy to use crypto library.</Run>
-                </Paragraph>
-                <Paragraph>
-                    <Run>Copyright © 2013-2018 Frank Denis &lt;j at pureftpd dot org&gt;</Run>
-                </Paragraph>
-                <Paragraph>Used under the
-                    <Hyperlink NavigateUri="https://github.com/jedisct1/libsodium/blob/master/LICENSE">ISC License</Hyperlink>
-                </Paragraph>
+                    <Paragraph>
+                        <Bold>libsodium</Bold>
+                        <Run>- A modern, portable, easy to use crypto library.</Run>
+                    </Paragraph>
+                    <Paragraph>
+                        <Run>Copyright © 2013-2018 Frank Denis &lt;j at pureftpd dot org&gt;</Run>
+                    </Paragraph>
+                    <Paragraph>Used under the
+                        <Hyperlink NavigateUri="https://github.com/jedisct1/libsodium/blob/master/LICENSE">ISC License</Hyperlink>
+                    </Paragraph>
 
-                <Paragraph/>
+                    <Paragraph/>
 
-                <Paragraph>
-                    <Bold>libopus</Bold>
-                    <Run>- Modern audio compression for the internet.</Run>
-                </Paragraph>
-                <Paragraph>
-                    <Run>Copyright © 2001-2011 Xiph.Org, Skype Limited, Octasic, Jean-Marc Valin, Timothy B. Terriberry, CSIRO, Gregory Maxwell, Mark Borgerding, Erik de Castro Lopo</Run>
-                </Paragraph>
-                <Paragraph>Used under the
-                    <Hyperlink NavigateUri="https://github.com/xiph/opus/blob/master/LICENSE_PLEASE_READ.txt">BSD License</Hyperlink>
-                </Paragraph>
+                    <Paragraph>
+                        <Bold>libopus</Bold>
+                        <Run>- Modern audio compression for the internet.</Run>
+                    </Paragraph>
+                    <Paragraph>
+                        <Run>Copyright © 2001-2011 Xiph.Org, Skype Limited, Octasic, Jean-Marc Valin, Timothy B. Terriberry, CSIRO, Gregory Maxwell, Mark Borgerding, Erik de Castro Lopo</Run>
+                    </Paragraph>
+                    <Paragraph>Used under the
+                        <Hyperlink NavigateUri="https://github.com/xiph/opus/blob/master/LICENSE_PLEASE_READ.txt">BSD License</Hyperlink>
+                    </Paragraph>
 
-                <Paragraph/>
+                    <Paragraph/>
 
-                <Paragraph>
-                    <Bold>QueryString.NET</Bold>
-                    <Run>- A QueryString library for generating and parsing query strings using C#.</Run>
-                </Paragraph>
-                <Paragraph>
-                    <Run>Copyright © 2015 Windows Notifications</Run>
-                </Paragraph>
-                <Paragraph>Used under the
-                    <Hyperlink NavigateUri="https://github.com/WindowsNotifications/QueryString.NET/blob/master/LICENSE">MIT License</Hyperlink>
-                </Paragraph>
+                    <Paragraph>
+                        <Bold>QueryString.NET</Bold>
+                        <Run>- A QueryString library for generating and parsing query strings using C#.</Run>
+                    </Paragraph>
+                    <Paragraph>
+                        <Run>Copyright © 2015 Windows Notifications</Run>
+                    </Paragraph>
+                    <Paragraph>Used under the
+                        <Hyperlink NavigateUri="https://github.com/WindowsNotifications/QueryString.NET/blob/master/LICENSE">MIT License</Hyperlink>
+                    </Paragraph>
 
-                <Paragraph/>
+                    <Paragraph/>
 
-                <Paragraph>
-                    <Bold>Unicode.NET</Bold>
-                    <Run>- A Unicode library for .NET, supporting UTF8, UTF16, and UTF32.</Run>
-                </Paragraph>
-                <Paragraph>
-                    <Run>Copyright © 2017 NeoSmart Technologies</Run>
-                    <Hyperlink NavigateUri="https://neosmart.net/">https://neosmart.net/</Hyperlink>
-                </Paragraph>
-                <Paragraph>Used under the
-                    <Hyperlink NavigateUri="https://github.com/WindowsNotifications/QueryString.NET/blob/master/LICENSE">MIT License</Hyperlink>
-                </Paragraph>
+                    <Paragraph>
+                        <Bold>Unicode.NET</Bold>
+                        <Run>- A Unicode library for .NET, supporting UTF8, UTF16, and UTF32.</Run>
+                    </Paragraph>
+                    <Paragraph>
+                        <Run>Copyright © 2017 NeoSmart Technologies</Run>
+                        <Hyperlink NavigateUri="https://neosmart.net/">https://neosmart.net/</Hyperlink>
+                    </Paragraph>
+                    <Paragraph>Used under the
+                        <Hyperlink NavigateUri="https://github.com/WindowsNotifications/QueryString.NET/blob/master/LICENSE">MIT License</Hyperlink>
+                    </Paragraph>
 
-                <Paragraph/>
-
-                <Paragraph>
-                    <Run>Discord, the Discord Logo, Clyde and so on are trademarks of Discord Inc. Unicord is in no way associated with nor endorced by these people, but they're cool!</Run>
-                </Paragraph>
-
-                <Paragraph/>
-
-                <Paragraph>
-                    <Run Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" Text="Hey you read all this? You're pretty cool too, hit me up! @WamWooWam#6402"/>
-                </Paragraph>
+                    <Paragraph/>
 
             </RichTextBlock>
+            
+            <Border BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="0,1.5,0,0"
+                    Margin="-28,0,-28,0"
+                    Padding="0,16,0,0"/>
+            <StackPanel>
+                <TextBlock TextWrapping="Wrap" Margin="20,0">
+                        <Run>Discord, the Discord Logo, Clyde and so on are trademarks of Discord Inc. Unicord is in no way associated with nor endorced by these people, but they're cool!</Run>
+                </TextBlock>
+
+                <TextBlock Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}"
+                            Text="Hey you read all this? You're pretty cool too, hit me up! @WamWooWam#6402"
+                            TextWrapping="Wrap"
+                            Margin="20,12,20,0"
+                            IsTextSelectionEnabled="True"/>
+            </StackPanel>
         </StackPanel>
-    </Grid>
+    </muxc:Expander>
 </Page>

--- a/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml
@@ -36,7 +36,7 @@
             <Grid>
                 <Grid.RowDefinitions>
                     <!-- Banner -->
-                    <RowDefinition Height="120"/>
+                    <RowDefinition Height="100"/>
                     <!-- Content -->
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>

--- a/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml
@@ -46,6 +46,28 @@
                         Background="{ThemeResource LayerFillColorAltBrush}"
                     CornerRadius="{ThemeResource AccountsSettings_ProfileCard_BannerCornerRadius}" />
 
+                <Button Grid.Row="0"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
+                        Margin="0,8,8,0"
+                        Padding="4"
+                        Background="Transparent"
+                        BorderBrush="Transparent"
+                        ToolTipService.ToolTip="More">
+                    <Button.Content>
+                        <FontIcon Glyph="&#xE10C;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                    </Button.Content>
+                    <Button.Flyout>
+                        <MenuFlyout>
+                            <MenuFlyoutItem Text="Copy User ID" Click="CopyUserId_Click">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xEC7A;" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                        </MenuFlyout>
+                    </Button.Flyout>
+                </Button>
+
                 <!-- Content area -->
                 <Grid Grid.Row="1" Margin="16">
                     <Grid.RowDefinitions>

--- a/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml
@@ -8,59 +8,161 @@
     xmlns:lib="using:Microsoft.UI.Xaml.Controls"
     xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:models="using:Unicord.Universal.Models"
+    xmlns:presence="using:Unicord.Universal.Controls.Presence"
+    xmlns:users="using:Unicord.Universal.Controls.Users"
     xmlns:settings="using:SettingsControl"
     mc:Ignorable="d">
     <Page.DataContext>
         <models:AccountsSettingsModel />
     </Page.DataContext>
 
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
+    <ScrollViewer>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
 
         <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                 BorderThickness="1"
-                CornerRadius="4">
-            <Grid Margin="16">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <lib:PersonPicture ProfilePicture="{Binding User.AvatarUrl}" Width="96" Height="96" Margin="0,0,16,0"/>
-                <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                    <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}">
-                        <Run Foreground="{ThemeResource ApplicationForegroundThemeBrush}" Text="{Binding User.Username, Mode=OneWay}"/>#<Run Text="{Binding User.Discriminator, Mode=OneWay}"/>
-                    </TextBlock>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock x:Name="email" VerticalAlignment="Center"/>
-                        <HyperlinkButton Name="EmailRevealButton" x:Uid="/AccountsSettingsPage/EmailRevealButton" Style="{ThemeResource TextBlockButtonStyle}" VerticalAlignment="Center" Padding="2" Visibility="Visible" Click="EmailRevealButton_Click"/>
-                        <HyperlinkButton Name="EmailHideButton" x:Uid="/AccountsSettingsPage/EmailHideButton" Style="{ThemeResource TextBlockButtonStyle}" VerticalAlignment="Center" Padding="2" Visibility="Collapsed" Click="EmailHideButton_Click"/>
-                    </StackPanel>
-                </StackPanel>
+            CornerRadius="{ThemeResource AccountsSettings_ProfileCard_CornerRadius}"
+                MaxWidth="650">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <!-- Banner -->
+                    <RowDefinition Height="120"/>
+                    <!-- Content -->
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <!-- Banner area (visual only) -->
+                <Border Grid.Row="0"
+                        Background="{ThemeResource LayerFillColorAltBrush}"
+                    CornerRadius="{ThemeResource AccountsSettings_ProfileCard_BannerCornerRadius}" />
+
+                <!-- Content area -->
+                <Grid Grid.Row="1" Margin="16">
+                    <Grid.RowDefinitions>
+                        <!-- Avatar + name row (avatar overlaps banner) -->
+                        <RowDefinition Height="Auto"/>
+                        <!-- Details grid -->
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <Grid Grid.Row="0" ColumnSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <Grid Width="88" Height="88" Margin="0,-44,0,0">
+                            <Border CornerRadius="44"
+                                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                BorderThickness="1"
+                                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" />
+
+                            <users:AvatarControl Margin="3"
+                                    Style="{ThemeResource LargeAvatarWithPresenceStyle}"
+                                    Source="{Binding User.AvatarUrl}"
+                                    Presence="{Binding UserPresence, Mode=OneWay}" />
+                        </Grid>
+
+                        <StackPanel Grid.Column="1" VerticalAlignment="Top" Margin="0,-4,0,0">
+                            <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}"
+                                       Text="{Binding User.GlobalName, Mode=OneWay}"
+                                       Visibility="{Binding User.GlobalName, Converter={StaticResource BoolVisibilityConverter}}"
+                                       TextTrimming="CharacterEllipsis"
+                                       IsTextSelectionEnabled="True"/>
+                            <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}"
+                                       Text="{Binding User.Username, Mode=OneWay}"
+                                       Visibility="{Binding User.GlobalName, Converter={StaticResource InverseBoolVisibilityConverter}}"
+                                       TextTrimming="CharacterEllipsis"
+                                       IsTextSelectionEnabled="True"/>
+                        </StackPanel>
+                    </Grid>
+
+                    <Grid Grid.Row="1" RowSpacing="16" Margin="5,16,0,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <Grid Grid.Row="0" ColumnSpacing="12" Visibility="{Binding User.GlobalName, Converter={StaticResource BoolVisibilityConverter}}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <StackPanel>
+                                <TextBlock Text="Display Name"
+                                           FontSize="12"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           Margin="0,0,0,4"/>
+                                <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}"
+                                           Text="{Binding User.GlobalName, Mode=OneWay}"
+                                           IsTextSelectionEnabled="True"/>
+                            </StackPanel>
+                        </Grid>
+
+                        <Grid Grid.Row="1" ColumnSpacing="12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <StackPanel>
+                                <TextBlock Text="Username"
+                                           FontSize="12"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           Margin="0,0,0,4"/>
+                                <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}"
+                                           Text="{Binding User.Username, Mode=OneWay}"
+                                           IsTextSelectionEnabled="True"/>
+                            </StackPanel>
+                        </Grid>
+
+                        <Grid Grid.Row="2" ColumnSpacing="12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <StackPanel>
+                                <TextBlock Text="Email"
+                                           FontSize="12"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           Margin="0,0,0,4"/>
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <TextBlock x:Name="email" VerticalAlignment="Center" IsTextSelectionEnabled="True"/>
+                                    <HyperlinkButton Name="EmailRevealButton" x:Uid="/AccountsSettingsPage/EmailRevealButton" Style="{ThemeResource TextBlockButtonStyle}" VerticalAlignment="Center" Padding="2" Visibility="Visible" Click="EmailRevealButton_Click"/>
+                                    <HyperlinkButton Name="EmailHideButton" x:Uid="/AccountsSettingsPage/EmailHideButton" Style="{ThemeResource TextBlockButtonStyle}" VerticalAlignment="Center" Padding="2" Visibility="Collapsed" Click="EmailHideButton_Click"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </Grid>
+                    </Grid>
+                </Grid>
             </Grid>
         </Border>
 
         <TextBlock x:Uid="/AccountsSettingsPage/FriendsText" Grid.Row="1" Style="{ThemeResource BaseTextBlockStyle}" Margin="4,16"/>
 
         <StackPanel Grid.Row="2">
-            <settings:SettingsBlockControl x:Uid="/AccountsSettingsPage/SyncContactsBlock">
+            <settings:SettingsBlockControl x:Uid="/AccountsSettingsPage/SyncContactsBlock"
+                                           Visibility="{Binding IsSyncContactsVisible, Converter={StaticResource BoolVisibilityConverter}}">
                 <settings:SettingsBlockControl.Icon>
                     <SymbolIcon Symbol="People"/>
                 </settings:SettingsBlockControl.Icon>
                 <ToggleSwitch x:Name="syncContactsSwitch" Style="{ThemeResource NoTextToggleSwitchStyle}" />
             </settings:SettingsBlockControl>
 
-            <settings:SettingsBlockControl x:Uid="/AccountsSettingsPage/BackgroundNotificationsBlock">
+            <settings:SettingsBlockControl x:Uid="/AccountsSettingsPage/BackgroundNotificationsBlock"
+                                           Description="{Binding BackgroundNotificationDescription}">
                 <settings:SettingsBlockControl.Icon>
-                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE7E7;"/>
+                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="{Binding BackgroundNotificationIcon}"/>
                 </settings:SettingsBlockControl.Icon>
                 <ToggleSwitch Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding BackgroundNotifications, Mode=TwoWay}" />
             </settings:SettingsBlockControl>
@@ -68,62 +170,69 @@
 
         <TextBlock x:Uid="/AccountsSettingsPage/StatisticsText" Grid.Row="3" Style="{ThemeResource BaseTextBlockStyle}" Margin="4,16"/>
         
-        <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="4"
-                Grid.Row="4"
-                Padding="16,12">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
+        <settings:SettingsBlockControl x:Uid="/AccountsSettingsPage/StatisticsBlock"
+                           Grid.Row="4"
+                           IsExpanded="True">
+            <settings:SettingsBlockControl.Icon>
+                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE9D9;"/>
+            </settings:SettingsBlockControl.Icon>
+            <Button x:Name="CopyStatisticsButton"
+                    x:Uid="/AccountsSettingsPage/CopyStatisticsButton"
+                    Click="CopyStatisticsButton_Click">
+                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8C8;" FontSize="16"/>
+            </Button>
+            <settings:SettingsBlockControl.ExpandableContent>
+                <Grid Padding="20,8" ColumnSpacing="24">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
 
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
 
-                <TextBlock Grid.Row="0" Text="Friends" FontWeight="Bold" />
-                <TextBlock Grid.Row="0" Grid.Column="1" TextAlignment="Right" Text="{Binding FriendCountString}"/>
+                    <TextBlock Grid.Row="0" Text="Friends" FontWeight="Normal" IsTextSelectionEnabled="False" />
+                    <TextBlock Grid.Row="0" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding FriendCountString}"/>
 
-                <TextBlock Grid.Row="1" Text="Servers" FontWeight="Bold" />
-                <TextBlock Grid.Row="1" Grid.Column="1" TextAlignment="Right" Text="{Binding ServerCountString}"/>
+                    <TextBlock Grid.Row="1" Text="Servers" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
+                    <TextBlock Grid.Row="1" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding ServerCountString}" Margin="0,8,0,0"/>
 
-                <TextBlock Grid.Row="2" Text="Server Channels" FontWeight="Bold" />
-                <TextBlock Grid.Row="2" Grid.Column="1" TextAlignment="Right" Text="{Binding ChannelsCountString}"/>
+                    <TextBlock Grid.Row="2" Text="Server Channels" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
+                    <TextBlock Grid.Row="2" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding ChannelsCountString}" Margin="0,8,0,0"/>
 
-                <TextBlock Grid.Row="3" Text="Server Members" FontWeight="Bold" />
-                <TextBlock Grid.Row="3" Grid.Column="1" TextAlignment="Right" Text="{Binding MemberCountString}"/>
+                    <TextBlock Grid.Row="3" Text="Server Members" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
+                    <TextBlock Grid.Row="3" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding MemberCountString}" Margin="0,8,0,0"/>
 
-                <TextBlock Grid.Row="4" Text="DM Channels" FontWeight="Bold" />
-                <TextBlock Grid.Row="4" Grid.Column="1" TextAlignment="Right" Text="{Binding OpenDMCountString}"/>
+                    <TextBlock Grid.Row="4" Text="DM Channels" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
+                    <TextBlock Grid.Row="4" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding OpenDMCountString}" Margin="0,8,0,0"/>
 
-                <TextBlock Grid.Row="5" Text="Synced Users" FontWeight="Bold" />
-                <TextBlock Grid.Row="5" Grid.Column="1" TextAlignment="Right" Text="{Binding SynchedUserCountString}"/>
+                    <TextBlock Grid.Row="5" Text="Synced Users" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
+                    <TextBlock Grid.Row="5" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding SynchedUserCountString}" Margin="0,8,0,0"/>
 
-                <TextBlock Grid.Row="6" Text="Synced Presences" FontWeight="Bold" />
-                <TextBlock Grid.Row="6" Grid.Column="1" TextAlignment="Right" Text="{Binding SynchedPresenceCountString}"/>
+                    <TextBlock Grid.Row="6" Text="Synced Presences" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
+                    <TextBlock Grid.Row="6" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding SynchedPresenceCountString}" Margin="0,8,0,0"/>
 
-                <TextBlock Grid.Row="7" Text="Emotes" FontWeight="Bold" />
-                <TextBlock Grid.Row="7" Grid.Column="1" TextAlignment="Right" Text="{Binding EmoteCountString}"/>
-            </Grid>
-        </Border>
+                    <TextBlock Grid.Row="7" Text="Emotes" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
+                    <TextBlock Grid.Row="7" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding EmoteCountString}" Margin="0,8,0,0"/>
+                </Grid>
+            </settings:SettingsBlockControl.ExpandableContent>
+        </settings:SettingsBlockControl>
 
         <settings:SettingsBlockControl x:Uid="/AccountsSettingsPage/LogoutBlock"
-                                       IsClickable="True"
-                                       Click="LogoutButton_Click"
                                        Grid.Row="6">
             <settings:SettingsBlockControl.Icon>
                 <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xF3B1;"/>
             </settings:SettingsBlockControl.Icon>
+            <Button x:Uid="/AccountsSettingsPage/LogoutButton" Click="LogoutButton_Click" Foreground="Red" />
         </settings:SettingsBlockControl>
     </Grid>
+    </ScrollViewer>
 </Page>

--- a/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml
@@ -63,11 +63,11 @@
 
                         <Grid Width="88" Height="88" Margin="0,-44,0,0">
                             <Border CornerRadius="44"
-                                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                                BorderThickness="1"
+                                BorderBrush="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                BorderThickness="6"
                                 Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" />
 
-                            <users:AvatarControl Margin="3"
+                            <users:AvatarControl Margin="6"
                                     Style="{ThemeResource LargeAvatarWithPresenceStyle}"
                                     Source="{Binding User.AvatarUrl}"
                                     Presence="{Binding UserPresence, Mode=OneWay}" />
@@ -101,10 +101,12 @@
                             </Grid.ColumnDefinitions>
                             <StackPanel>
                                 <TextBlock Text="Display Name"
-                                           FontSize="12"
+                                           Style="{ThemeResource CaptionTextBlockStyle}"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                            Margin="0,0,0,4"/>
-                                <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}"
+                                    <TextBlock Style="{ThemeResource BodyTextBlockStyle}"
+                                           FontWeight="SemiBold"
+                                           Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                                            Text="{Binding User.GlobalName, Mode=OneWay}"
                                            IsTextSelectionEnabled="True"/>
                             </StackPanel>
@@ -117,10 +119,12 @@
                             </Grid.ColumnDefinitions>
                             <StackPanel>
                                 <TextBlock Text="Username"
-                                           FontSize="12"
+                                           Style="{ThemeResource CaptionTextBlockStyle}"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                            Margin="0,0,0,4"/>
-                                <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}"
+                                    <TextBlock Style="{ThemeResource BodyTextBlockStyle}"
+                                           FontWeight="SemiBold"
+                                           Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                                            Text="{Binding User.Username, Mode=OneWay}"
                                            IsTextSelectionEnabled="True"/>
                             </StackPanel>
@@ -133,11 +137,14 @@
                             </Grid.ColumnDefinitions>
                             <StackPanel>
                                 <TextBlock Text="Email"
-                                           FontSize="12"
+                                           Style="{ThemeResource CaptionTextBlockStyle}"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                            Margin="0,0,0,4"/>
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <TextBlock x:Name="email" VerticalAlignment="Center" IsTextSelectionEnabled="True"/>
+                                        <TextBlock x:Name="email" VerticalAlignment="Center" IsTextSelectionEnabled="True" 
+                                           Style="{ThemeResource BodyTextBlockStyle}"
+                                           FontWeight="SemiBold"
+                                           Foreground="{ThemeResource TextFillColorPrimaryBrush}"/>
                                     <HyperlinkButton Name="EmailRevealButton" x:Uid="/AccountsSettingsPage/EmailRevealButton" Style="{ThemeResource TextBlockButtonStyle}" VerticalAlignment="Center" Padding="2" Visibility="Visible" Click="EmailRevealButton_Click"/>
                                     <HyperlinkButton Name="EmailHideButton" x:Uid="/AccountsSettingsPage/EmailHideButton" Style="{ThemeResource TextBlockButtonStyle}" VerticalAlignment="Center" Padding="2" Visibility="Collapsed" Click="EmailHideButton_Click"/>
                                 </StackPanel>

--- a/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml
@@ -28,101 +28,101 @@
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
-        <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                 BorderThickness="1"
             CornerRadius="{ThemeResource AccountsSettings_ProfileCard_CornerRadius}"
                 MaxWidth="650">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <!-- Banner -->
-                    <RowDefinition Height="100"/>
-                    <!-- Content -->
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-
-                <!-- Banner area (visual only) -->
-                <Border Grid.Row="0"
-                        Background="{ThemeResource LayerFillColorAltBrush}"
-                    CornerRadius="{ThemeResource AccountsSettings_ProfileCard_BannerCornerRadius}" />
-
-                <Button Grid.Row="0"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Top"
-                        Margin="0,8,8,0"
-                        Padding="4"
-                        Background="Transparent"
-                        BorderBrush="Transparent"
-                        ToolTipService.ToolTip="More">
-                    <Button.Content>
-                        <FontIcon Glyph="&#xE10C;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
-                    </Button.Content>
-                    <Button.Flyout>
-                        <MenuFlyout>
-                            <MenuFlyoutItem Text="Copy User ID" Click="CopyUserId_Click">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xEC7A;" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
-                        </MenuFlyout>
-                    </Button.Flyout>
-                </Button>
-
-                <!-- Content area -->
-                <Grid Grid.Row="1" Margin="16">
+                <Grid>
                     <Grid.RowDefinitions>
-                        <!-- Avatar + name row (avatar overlaps banner) -->
-                        <RowDefinition Height="Auto"/>
-                        <!-- Details grid -->
+                        <!-- Banner -->
+                        <RowDefinition Height="100"/>
+                        <!-- Content -->
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
 
-                    <Grid Grid.Row="0" ColumnSpacing="12">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
+                    <!-- Banner area (visual only) -->
+                    <Border Grid.Row="0"
+                        Background="{ThemeResource LayerFillColorAltBrush}"
+                    CornerRadius="{ThemeResource AccountsSettings_ProfileCard_BannerCornerRadius}" />
 
-                        <Grid Width="88" Height="88" Margin="0,-44,0,0">
-                            <Border CornerRadius="44"
+                    <Button Grid.Row="0"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top"
+                            Margin="0,8,8,0"
+                            Padding="4"
+                            Background="Transparent"
+                            BorderBrush="Transparent"
+                            ToolTipService.ToolTip="More">
+                        <Button.Content>
+                            <FontIcon Glyph="&#xE10C;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                        </Button.Content>
+                        <Button.Flyout>
+                            <MenuFlyout>
+                                <MenuFlyoutItem Text="Copy User ID" Click="CopyUserId_Click">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon Glyph="&#xEC7A;" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
+                            </MenuFlyout>
+                        </Button.Flyout>
+                    </Button>
+
+                    <!-- Content area -->
+                    <Grid Grid.Row="1" Margin="16">
+                        <Grid.RowDefinitions>
+                            <!-- Avatar + name row (avatar overlaps banner) -->
+                            <RowDefinition Height="Auto"/>
+                            <!-- Details grid -->
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <Grid Grid.Row="0" ColumnSpacing="12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+
+                            <Grid Width="88" Height="88" Margin="0,-44,0,0">
+                                <Border CornerRadius="44"
                                 BorderBrush="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                                 BorderThickness="6"
                                 Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" />
 
-                            <users:AvatarControl Margin="6"
+                                <users:AvatarControl Margin="6"
                                     Style="{ThemeResource LargeAvatarWithPresenceStyle}"
                                     Source="{Binding User.AvatarUrl}"
                                     Presence="{Binding UserPresence, Mode=OneWay}" />
-                        </Grid>
+                            </Grid>
 
-                        <StackPanel Grid.Column="1" VerticalAlignment="Top" Margin="0,-4,0,0">
-                            <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}"
+                            <StackPanel Grid.Column="1" VerticalAlignment="Top" Margin="0,-4,0,0">
+                                <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}"
                                        Text="{Binding User.GlobalName, Mode=OneWay}"
                                        Visibility="{Binding User.GlobalName, Converter={StaticResource BoolVisibilityConverter}}"
                                        TextTrimming="CharacterEllipsis"
                                        IsTextSelectionEnabled="True"/>
-                            <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}"
+                                <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}"
                                        Text="{Binding User.Username, Mode=OneWay}"
                                        Visibility="{Binding User.GlobalName, Converter={StaticResource InverseBoolVisibilityConverter}}"
                                        TextTrimming="CharacterEllipsis"
                                        IsTextSelectionEnabled="True"/>
-                        </StackPanel>
-                    </Grid>
+                            </StackPanel>
+                        </Grid>
 
-                    <Grid Grid.Row="1" RowSpacing="16" Margin="5,16,0,0">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
+                        <Grid Grid.Row="1" RowSpacing="16" Margin="5,16,0,0">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
 
-                        <Grid Grid.Row="0" ColumnSpacing="12" Visibility="{Binding User.GlobalName, Converter={StaticResource BoolVisibilityConverter}}">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-                            <StackPanel>
-                                <TextBlock Text="Display Name"
+                            <Grid Grid.Row="0" ColumnSpacing="12" Visibility="{Binding User.GlobalName, Converter={StaticResource BoolVisibilityConverter}}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel>
+                                    <TextBlock Text="Display Name"
                                            Style="{ThemeResource CaptionTextBlockStyle}"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                            Margin="0,0,0,4"/>
@@ -131,16 +131,16 @@
                                            Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                                            Text="{Binding User.GlobalName, Mode=OneWay}"
                                            IsTextSelectionEnabled="True"/>
-                            </StackPanel>
-                        </Grid>
+                                </StackPanel>
+                            </Grid>
 
-                        <Grid Grid.Row="1" ColumnSpacing="12">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-                            <StackPanel>
-                                <TextBlock Text="Username"
+                            <Grid Grid.Row="1" ColumnSpacing="12">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel>
+                                    <TextBlock Text="Username"
                                            Style="{ThemeResource CaptionTextBlockStyle}"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                            Margin="0,0,0,4"/>
@@ -149,70 +149,70 @@
                                            Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                                            Text="{Binding User.Username, Mode=OneWay}"
                                            IsTextSelectionEnabled="True"/>
-                            </StackPanel>
-                        </Grid>
+                                </StackPanel>
+                            </Grid>
 
-                        <Grid Grid.Row="2" ColumnSpacing="12">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-                            <StackPanel>
-                                <TextBlock Text="Email"
+                            <Grid Grid.Row="2" ColumnSpacing="12">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel>
+                                    <TextBlock Text="Email"
                                            Style="{ThemeResource CaptionTextBlockStyle}"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                            Margin="0,0,0,4"/>
-                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <StackPanel Orientation="Horizontal" Spacing="8">
                                         <TextBlock x:Name="email" VerticalAlignment="Center" IsTextSelectionEnabled="True" 
                                            Style="{ThemeResource BodyTextBlockStyle}"
                                            FontWeight="SemiBold"
                                            Foreground="{ThemeResource TextFillColorPrimaryBrush}"/>
-                                    <HyperlinkButton Name="EmailRevealButton" x:Uid="/AccountsSettingsPage/EmailRevealButton" Style="{ThemeResource TextBlockButtonStyle}" VerticalAlignment="Center" Padding="2" Visibility="Visible" Click="EmailRevealButton_Click"/>
-                                    <HyperlinkButton Name="EmailHideButton" x:Uid="/AccountsSettingsPage/EmailHideButton" Style="{ThemeResource TextBlockButtonStyle}" VerticalAlignment="Center" Padding="2" Visibility="Collapsed" Click="EmailHideButton_Click"/>
+                                        <HyperlinkButton Name="EmailRevealButton" x:Uid="/AccountsSettingsPage/EmailRevealButton" Style="{ThemeResource TextBlockButtonStyle}" VerticalAlignment="Center" Padding="2" Visibility="Visible" Click="EmailRevealButton_Click"/>
+                                        <HyperlinkButton Name="EmailHideButton" x:Uid="/AccountsSettingsPage/EmailHideButton" Style="{ThemeResource TextBlockButtonStyle}" VerticalAlignment="Center" Padding="2" Visibility="Collapsed" Click="EmailHideButton_Click"/>
+                                    </StackPanel>
                                 </StackPanel>
-                            </StackPanel>
+                            </Grid>
                         </Grid>
                     </Grid>
                 </Grid>
-            </Grid>
-        </Border>
+            </Border>
 
-        <TextBlock x:Uid="/AccountsSettingsPage/FriendsText" Grid.Row="1" Style="{ThemeResource BaseTextBlockStyle}" Margin="4,16"/>
+            <TextBlock x:Uid="/AccountsSettingsPage/FriendsText" Grid.Row="1" Style="{ThemeResource BaseTextBlockStyle}" Margin="4,16"/>
 
-        <StackPanel Grid.Row="2">
-            <settings:SettingsBlockControl x:Uid="/AccountsSettingsPage/SyncContactsBlock"
+            <StackPanel Grid.Row="2">
+                <settings:SettingsBlockControl x:Uid="/AccountsSettingsPage/SyncContactsBlock"
                                            Visibility="{Binding IsSyncContactsVisible, Converter={StaticResource BoolVisibilityConverter}}">
-                <settings:SettingsBlockControl.Icon>
-                    <SymbolIcon Symbol="People"/>
-                </settings:SettingsBlockControl.Icon>
-                <ToggleSwitch x:Name="syncContactsSwitch" Style="{ThemeResource NoTextToggleSwitchStyle}" />
-            </settings:SettingsBlockControl>
+                    <settings:SettingsBlockControl.Icon>
+                        <SymbolIcon Symbol="People"/>
+                    </settings:SettingsBlockControl.Icon>
+                    <ToggleSwitch x:Name="syncContactsSwitch" Style="{ThemeResource NoTextToggleSwitchStyle}" />
+                </settings:SettingsBlockControl>
 
-            <settings:SettingsBlockControl x:Uid="/AccountsSettingsPage/BackgroundNotificationsBlock"
+                <settings:SettingsBlockControl x:Uid="/AccountsSettingsPage/BackgroundNotificationsBlock"
                                            Description="{Binding BackgroundNotificationDescription}">
-                <settings:SettingsBlockControl.Icon>
-                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="{Binding BackgroundNotificationIcon}"/>
-                </settings:SettingsBlockControl.Icon>
-                <ToggleSwitch Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding BackgroundNotifications, Mode=TwoWay}" />
-            </settings:SettingsBlockControl>
-        </StackPanel>
+                    <settings:SettingsBlockControl.Icon>
+                        <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="{Binding BackgroundNotificationIcon}"/>
+                    </settings:SettingsBlockControl.Icon>
+                    <ToggleSwitch Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding BackgroundNotifications, Mode=TwoWay}" />
+                </settings:SettingsBlockControl>
+            </StackPanel>
 
-        <TextBlock x:Uid="/AccountsSettingsPage/StatisticsText" Grid.Row="3" Style="{ThemeResource BaseTextBlockStyle}" Margin="4,16"/>
-        
-        <settings:SettingsBlockControl x:Uid="/AccountsSettingsPage/StatisticsBlock"
+            <TextBlock x:Uid="/AccountsSettingsPage/StatisticsText" Grid.Row="3" Style="{ThemeResource BaseTextBlockStyle}" Margin="4,16"/>
+
+            <settings:SettingsBlockControl x:Uid="/AccountsSettingsPage/StatisticsBlock"
                            Grid.Row="4"
                            IsExpanded="True">
-            <settings:SettingsBlockControl.Icon>
-                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE9D9;"/>
-            </settings:SettingsBlockControl.Icon>
-            <Button x:Name="CopyStatisticsButton"
+                <settings:SettingsBlockControl.Icon>
+                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE9D9;"/>
+                </settings:SettingsBlockControl.Icon>
+                <Button x:Name="CopyStatisticsButton"
                     x:Uid="/AccountsSettingsPage/CopyStatisticsButton"
                     Click="CopyStatisticsButton_Click"
                     Margin="0,0,-12,0">
-                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8C8;" FontSize="16"/>
-            </Button>
-            <settings:SettingsBlockControl.ExpandableContent>
-                <Grid Padding="20,8" ColumnSpacing="24">
+                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8C8;" FontSize="16"/>
+                </Button>
+                <settings:SettingsBlockControl.ExpandableContent>
+                    <Grid Padding="20,8" ColumnSpacing="24">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="Auto"/>
@@ -229,40 +229,40 @@
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
-                    <TextBlock Grid.Row="0" Text="Friends" FontWeight="Normal" IsTextSelectionEnabled="False" />
-                    <TextBlock Grid.Row="0" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding FriendCountString}"/>
+                        <TextBlock Grid.Row="0" Text="Friends" FontWeight="Normal" IsTextSelectionEnabled="False" />
+                        <TextBlock Grid.Row="0" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding FriendCountString}"/>
 
-                    <TextBlock Grid.Row="1" Text="Servers" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
-                    <TextBlock Grid.Row="1" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding ServerCountString}" Margin="0,8,0,0"/>
+                        <TextBlock Grid.Row="1" Text="Servers" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
+                        <TextBlock Grid.Row="1" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding ServerCountString}" Margin="0,8,0,0"/>
 
-                    <TextBlock Grid.Row="2" Text="Server Channels" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
-                    <TextBlock Grid.Row="2" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding ChannelsCountString}" Margin="0,8,0,0"/>
+                        <TextBlock Grid.Row="2" Text="Server Channels" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
+                        <TextBlock Grid.Row="2" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding ChannelsCountString}" Margin="0,8,0,0"/>
 
-                    <TextBlock Grid.Row="3" Text="Server Members" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
-                    <TextBlock Grid.Row="3" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding MemberCountString}" Margin="0,8,0,0"/>
+                        <TextBlock Grid.Row="3" Text="Server Members" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
+                        <TextBlock Grid.Row="3" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding MemberCountString}" Margin="0,8,0,0"/>
 
-                    <TextBlock Grid.Row="4" Text="DM Channels" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
-                    <TextBlock Grid.Row="4" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding OpenDMCountString}" Margin="0,8,0,0"/>
+                        <TextBlock Grid.Row="4" Text="DM Channels" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
+                        <TextBlock Grid.Row="4" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding OpenDMCountString}" Margin="0,8,0,0"/>
 
-                    <TextBlock Grid.Row="5" Text="Synced Users" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
-                    <TextBlock Grid.Row="5" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding SynchedUserCountString}" Margin="0,8,0,0"/>
+                        <TextBlock Grid.Row="5" Text="Synced Users" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
+                        <TextBlock Grid.Row="5" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding SynchedUserCountString}" Margin="0,8,0,0"/>
 
-                    <TextBlock Grid.Row="6" Text="Synced Presences" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
-                    <TextBlock Grid.Row="6" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding SynchedPresenceCountString}" Margin="0,8,0,0"/>
+                        <TextBlock Grid.Row="6" Text="Synced Presences" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
+                        <TextBlock Grid.Row="6" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding SynchedPresenceCountString}" Margin="0,8,0,0"/>
 
-                    <TextBlock Grid.Row="7" Text="Emotes" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
-                    <TextBlock Grid.Row="7" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding EmoteCountString}" Margin="0,8,0,0"/>
-                </Grid>
-            </settings:SettingsBlockControl.ExpandableContent>
-        </settings:SettingsBlockControl>
+                        <TextBlock Grid.Row="7" Text="Emotes" FontWeight="Normal" IsTextSelectionEnabled="False" Margin="0,8,0,0" />
+                        <TextBlock Grid.Row="7" Grid.Column="1" TextAlignment="Left" HorizontalAlignment="Left" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" IsTextSelectionEnabled="True" Text="{Binding EmoteCountString}" Margin="0,8,0,0"/>
+                    </Grid>
+                </settings:SettingsBlockControl.ExpandableContent>
+            </settings:SettingsBlockControl>
 
-        <settings:SettingsBlockControl x:Uid="/AccountsSettingsPage/LogoutBlock"
+            <settings:SettingsBlockControl x:Uid="/AccountsSettingsPage/LogoutBlock"
                                        Grid.Row="6">
-            <settings:SettingsBlockControl.Icon>
-                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xF3B1;"/>
-            </settings:SettingsBlockControl.Icon>
-            <Button x:Uid="/AccountsSettingsPage/LogoutButton" Click="LogoutButton_Click" Foreground="Red" />
-        </settings:SettingsBlockControl>
-    </Grid>
+                <settings:SettingsBlockControl.Icon>
+                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xF3B1;"/>
+                </settings:SettingsBlockControl.Icon>
+                <Button x:Uid="/AccountsSettingsPage/LogoutButton" Click="LogoutButton_Click" Foreground="Red" />
+            </settings:SettingsBlockControl>
+        </Grid>
     </ScrollViewer>
 </Page>

--- a/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml
@@ -178,7 +178,8 @@
             </settings:SettingsBlockControl.Icon>
             <Button x:Name="CopyStatisticsButton"
                     x:Uid="/AccountsSettingsPage/CopyStatisticsButton"
-                    Click="CopyStatisticsButton_Click">
+                    Click="CopyStatisticsButton_Click"
+                    Margin="0,0,-12,0">
                 <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8C8;" FontSize="16"/>
             </Button>
             <settings:SettingsBlockControl.ExpandableContent>

--- a/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml.cs
+++ b/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml.cs
@@ -105,5 +105,15 @@ namespace Unicord.Universal.Pages.Settings
             dataPackage.SetText(sb.ToString());
             Clipboard.SetContent(dataPackage);
         }
+
+        private void CopyUserId_Click(object sender, RoutedEventArgs e)
+        {
+            var userId = DiscordManager.Discord.CurrentUser?.Id;
+            if (userId == null) return;
+
+            var dataPackage = new DataPackage();
+            dataPackage.SetText(userId.Value.ToString());
+            Clipboard.SetContent(dataPackage);
+        }
     }
 }

--- a/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml.cs
+++ b/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Text;
 using Unicord.Universal.Controls;
 using Unicord.Universal.Integration;
 using Unicord.Universal.Parsers.Markdown;
 using Unicord.Universal.Services;
 using Unicord.Universal.Utilities;
+using Windows.ApplicationModel.DataTransfer;
 using Windows.ApplicationModel.Resources;
 using Windows.System;
 using Windows.UI.Xaml;
@@ -82,6 +84,26 @@ namespace Unicord.Universal.Pages.Settings
             var domain = split[1];
 
             return $"{new string('●', start.Length)}@{domain}";
+        }
+
+        private void CopyStatisticsButton_Click(object sender, RoutedEventArgs e)
+        {
+            var model = DataContext as Models.AccountsSettingsModel;
+            if (model == null) return;
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Friends\t\t\t{model.FriendCountString}");
+            sb.AppendLine($"Servers\t\t\t{model.ServerCountString}");
+            sb.AppendLine($"Server Channels\t\t{model.ChannelsCountString}");
+            sb.AppendLine($"Server Members\t\t{model.MemberCountString}");
+            sb.AppendLine($"DM Channels\t\t{model.OpenDMCountString}");
+            sb.AppendLine($"Synced Users\t\t{model.SynchedUserCountString}");
+            sb.AppendLine($"Synced Presences\t{model.SynchedPresenceCountString}");
+            sb.AppendLine($"Emotes\t\t\t{model.EmoteCountString}");
+
+            var dataPackage = new DataPackage();
+            dataPackage.SetText(sb.ToString());
+            Clipboard.SetContent(dataPackage);
         }
     }
 }

--- a/Unicord.Universal/Pages/Settings/MediaSettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/MediaSettingsPage.xaml
@@ -36,6 +36,9 @@
                         <ComboBoxItem x:Uid="/MediaSettingsPage/EncoderPrioritySpeed" />
                         <ComboBoxItem x:Uid="/MediaSettingsPage/EncoderPriorityQuality" />
                     </ComboBox>
+                    
+                    <Border Background="{ThemeResource ExpanderHeaderBorderBrush}" Height="1.5" Margin="-28,16,-28,16"/>
+                    
                     <TextBlock Style="{ThemeResource BaseTextBlockStyle}" x:Uid="/MediaSettingsPage/AudioOptionsHeader" Margin="0,0,0,12"/>
                     <Grid>
                         <Grid.ColumnDefinitions>

--- a/Unicord.Universal/Pages/Settings/MediaSettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/MediaSettingsPage.xaml
@@ -52,7 +52,7 @@
                     </Grid>
                 </StackPanel>
             </settings:SettingsBlockControl.ExpandableContent>
-            <ComboBox HorizontalAlignment="Stretch" SelectedIndex="{Binding AutoTranscodeMedia, Mode=TwoWay}" MinWidth="200">
+            <ComboBox HorizontalAlignment="Stretch" SelectedIndex="{Binding AutoTranscodeMedia, Mode=TwoWay}" MinWidth="200" Margin="0,0,-12,0">
                 <ComboBoxItem x:Uid="/MediaSettingsPage/AlwaysCompress"/>
                 <ComboBoxItem x:Uid="/MediaSettingsPage/CompressIfNeeded"/>
                 <ComboBoxItem x:Uid="/MediaSettingsPage/NeverCompress"/>

--- a/Unicord.Universal/Pages/Settings/MessagingSettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/MessagingSettingsPage.xaml
@@ -130,6 +130,18 @@
             <settings:SettingsBlockControl.Icon>
                 <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE790;"/>
             </settings:SettingsBlockControl.Icon>
+            <settings:SettingsBlockControl.AdditionalDescriptionContent>
+                <Button x:Name="ContrastLearnMoreButton"
+                        x:Uid="/MessagingSettingsPage/LearnMoreButton"
+                        HorizontalAlignment="Left"
+                        Style="{ThemeResource TextBlockButtonStyle}"
+                        Margin="0"
+                        Padding="0"
+                        MinHeight="0"
+                        MinWidth="0"
+                        VerticalAlignment="Center"
+                        Click="ContrastLearnMoreButton_Click"/>
+            </settings:SettingsBlockControl.AdditionalDescriptionContent>
             <settings:SettingsBlockControl.ExpandableContent>
                 <Grid Padding="20,8">
                     <Grid.RowDefinitions>
@@ -150,15 +162,6 @@
                             Grid.Row="1"
                             Grid.ColumnSpan="2"
                             Margin="0,8,0,0"/>
-
-                    <Button x:Name="ContrastLearnMoreButton"
-                            x:Uid="/MessagingSettingsPage/LearnMoreButton"
-                            Content="Learn More"
-                            HorizontalAlignment="Right"
-                            Grid.Row="2"
-                            Grid.ColumnSpan="2"
-                            Style="{ThemeResource TextBlockButtonStyle}"
-                            Click="ContrastLearnMoreButton_Click"/>
                 </Grid>
             </settings:SettingsBlockControl.ExpandableContent>
             <ToggleSwitch Grid.Column="1" Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding AdjustRoleColours, Mode=TwoWay}" Margin="0,0,-24,0" />

--- a/Unicord.Universal/Pages/Settings/NotificationsSettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/NotificationsSettingsPage.xaml
@@ -28,10 +28,13 @@
             <settings:SettingsBlockControl.Icon>
                 <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="{x:Bind NotificationGlyph, Mode=OneWay}"/>
             </settings:SettingsBlockControl.Icon>
+            <ToggleSwitch Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding EnableNotifications, Mode=TwoWay}" Margin="0,0,-24,0"/>
             <settings:SettingsBlockControl.ExpandableContent>
                 <StackPanel Margin="-16,-16,-16,-20">
                     <StackPanel.Resources>
-                        <SolidColorBrush x:Key="ExpanderHeaderBackground" Color="Transparent"/>                        <StaticResource x:Key="ExpanderHeaderBorderBrush" ResourceKey="CardStrokeColorDefaultBrush"/>                        <Thickness x:Key="ExpanderHeaderBorderThickness">0,0,0,1.5</Thickness>
+                        <SolidColorBrush x:Key="ExpanderHeaderBackground" Color="Transparent"/>
+                        <StaticResource x:Key="ExpanderHeaderBorderBrush" ResourceKey="CardStrokeColorDefaultBrush"/>
+                        <Thickness x:Key="ExpanderHeaderBorderThickness">0,0,0,1.5</Thickness>
                         <CornerRadius x:Key="ControlCornerRadius">0</CornerRadius>
                     </StackPanel.Resources>
                     <settings:SettingsBlockControl x:Uid="/NotificationsSettingsPage/EnableDesktopNotifications"
@@ -57,7 +60,6 @@
                     </settings:SettingsBlockControl>
                 </StackPanel>
             </settings:SettingsBlockControl.ExpandableContent>
-            <ToggleSwitch Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding EnableNotifications, Mode=TwoWay}" />
         </settings:SettingsBlockControl>
 
     </StackPanel>

--- a/Unicord.Universal/Pages/Settings/NotificationsSettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/NotificationsSettingsPage.xaml
@@ -22,30 +22,42 @@
                    TextWrapping="Wrap"/>
 
         <settings:SettingsBlockControl x:Uid="/NotificationsSettingsPage/EnableNotifications"
-                                       IsEnabled="{Binding IsPageEnabled}">
+                                       Description="{Binding EnableNotificationsDescription}"
+                                       IsEnabled="{Binding IsPageEnabled}"
+                                       IsExpanded="True">
+            <settings:SettingsBlockControl.Icon>
+                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="{x:Bind NotificationGlyph, Mode=OneWay}"/>
+            </settings:SettingsBlockControl.Icon>
+            <settings:SettingsBlockControl.ExpandableContent>
+                <StackPanel Margin="-16,-16,-16,-20">
+                    <StackPanel.Resources>
+                        <SolidColorBrush x:Key="ExpanderHeaderBackground" Color="Transparent"/>                        <StaticResource x:Key="ExpanderHeaderBorderBrush" ResourceKey="CardStrokeColorDefaultBrush"/>                        <Thickness x:Key="ExpanderHeaderBorderThickness">0,0,0,1.5</Thickness>
+                        <CornerRadius x:Key="ControlCornerRadius">0</CornerRadius>
+                    </StackPanel.Resources>
+                    <settings:SettingsBlockControl x:Uid="/NotificationsSettingsPage/EnableDesktopNotifications"
+                                                   Description="{Binding EnableDesktopNotificationsDescription}"
+                                                   IsEnabled="{Binding IsPageAndNotificationsEnabled}">
+                        <ToggleSwitch Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding EnableDesktopNotifications, Mode=TwoWay}" />
+                    </settings:SettingsBlockControl>
+
+                    <settings:SettingsBlockControl x:Uid="/NotificationsSettingsPage/EnableLiveTiles"
+                                                   Visibility="{Binding IsLiveTilesVisible, Converter={StaticResource BoolVisibilityConverter}}"
+                                                   IsEnabled="{Binding IsPageAndNotificationsEnabled}">
+                        <ToggleSwitch Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding EnableDesktopNotifications, Mode=TwoWay}" />
+                    </settings:SettingsBlockControl>
+
+                    <settings:SettingsBlockControl x:Uid="/NotificationsSettingsPage/EnableBadgeCount"
+                                                   IsEnabled="{Binding IsPageAndNotificationsEnabled}">
+                        <ToggleSwitch Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding EnableDesktopNotifications, Mode=TwoWay}" />
+                    </settings:SettingsBlockControl>
+
+                    <settings:SettingsBlockControl x:Uid="/NotificationsSettingsPage/EnableBadgeUnread"
+                                                   IsEnabled="{Binding IsPageAndNotificationsEnabled}">
+                        <ToggleSwitch Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding EnableDesktopNotifications, Mode=TwoWay}" />
+                    </settings:SettingsBlockControl>
+                </StackPanel>
+            </settings:SettingsBlockControl.ExpandableContent>
             <ToggleSwitch Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding EnableNotifications, Mode=TwoWay}" />
-        </settings:SettingsBlockControl>
-
-        <Border Margin="8,15,8,16" BorderThickness="0,1,0,0" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" />
-
-        <settings:SettingsBlockControl x:Uid="/NotificationsSettingsPage/EnableDesktopNotifications"
-                                       IsEnabled="{Binding IsPageAndNotificationsEnabled}">
-            <ToggleSwitch Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding EnableDesktopNotifications, Mode=TwoWay}" />
-        </settings:SettingsBlockControl>
-
-        <settings:SettingsBlockControl x:Uid="/NotificationsSettingsPage/EnableLiveTiles"
-                                       IsEnabled="{Binding IsPageAndNotificationsEnabled}">
-            <ToggleSwitch Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding EnableDesktopNotifications, Mode=TwoWay}" />
-        </settings:SettingsBlockControl>
-
-        <settings:SettingsBlockControl x:Uid="/NotificationsSettingsPage/EnableBadgeCount"
-                                       IsEnabled="{Binding IsPageAndNotificationsEnabled}">
-            <ToggleSwitch Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding EnableDesktopNotifications, Mode=TwoWay}" />
-        </settings:SettingsBlockControl>
-
-        <settings:SettingsBlockControl x:Uid="/NotificationsSettingsPage/EnableBadgeUnread"
-                                       IsEnabled="{Binding IsPageAndNotificationsEnabled}">
-            <ToggleSwitch Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding EnableDesktopNotifications, Mode=TwoWay}" />
         </settings:SettingsBlockControl>
 
     </StackPanel>

--- a/Unicord.Universal/Pages/Settings/NotificationsSettingsPage.xaml.cs
+++ b/Unicord.Universal/Pages/Settings/NotificationsSettingsPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Windows.UI.Xaml.Controls;
+﻿using Microsoft.Toolkit.Uwp.Helpers;
+using Windows.UI.Xaml.Controls;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -9,6 +10,8 @@ namespace Unicord.Universal.Pages.Settings
     /// </summary>
     public sealed partial class NotificationsSettingsPage : Page
     {
+        public string NotificationGlyph { get; } = SystemInformation.Instance.OperatingSystemVersion.Build >= 22000 ? "\uEA8F" : "\uE91C";
+
         public NotificationsSettingsPage()
         {
             this.InitializeComponent();

--- a/Unicord.Universal/Pages/Settings/SecuritySettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/SecuritySettingsPage.xaml
@@ -6,8 +6,9 @@
     xmlns:local="using:Unicord.Universal.Pages.Settings"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="using:Unicord.Universal.Models"
-    xmlns:settings="using:SettingsControl" 
+    xmlns:settings="using:SettingsControl"
     xmlns:controls="using:Unicord.Universal.Controls"
+    xmlns:lib="using:Microsoft.UI.Xaml.Controls"
     x:DefaultBindMode="TwoWay"
     Loaded="Page_Loaded"
     mc:Ignorable="d">
@@ -17,6 +18,18 @@
 
     <StackPanel>
 
+        <lib:InfoBar
+            x:Name="unavailableText"
+            Margin="0,4"
+            Severity="Warning"
+            IsClosable="False"
+            IsOpen="False"
+            Title="">
+            <lib:InfoBar.ActionButton>
+                <Button x:Name="OpenSettingsButton" x:Uid="/SecuritySettingsPage/OpenSettingsButton" Click="OpenSettingsButton_Click" HorizontalAlignment="Right"/>
+            </lib:InfoBar.ActionButton>
+        </lib:InfoBar>
+
         <settings:SettingsBlockControl x:Uid="/SecuritySettingsPage/DiagnosticDataBlock">
             <settings:SettingsBlockControl.Icon>
                 <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE946;"/>
@@ -24,16 +37,6 @@
             <ToggleSwitch Style="{ThemeResource NoTextToggleSwitchStyle}" IsOn="{Binding EnableAnalytics, Mode=TwoWay}" />
         </settings:SettingsBlockControl>
         
-        <controls:MarkdownTextBlock
-            x:Name="unavailableText"
-            x:Uid="/SecuritySettingsPage/WindowsHelloUnavailable"
-            Grid.Row="4"
-            Margin="0,4"
-            FontSize="12"
-            Background="Transparent"
-            Foreground="{StaticResource ErrorTextForegroundBrush}"
-            TextWrapping="Wrap"
-            LinkClicked="unavailableText_LinkClicked"/>
 
         <StackPanel Margin="4,16">
             <TextBlock x:Uid="/SecuritySettingsPage/WindowsHelloHeader"

--- a/Unicord.Universal/Pages/Settings/SecuritySettingsPage.xaml.cs
+++ b/Unicord.Universal/Pages/Settings/SecuritySettingsPage.xaml.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using Microsoft.AppCenter;
-using Unicord.Universal.Controls;
 using Unicord.Universal.Models;
-using Unicord.Universal.Parsers.Markdown;
+using Windows.ApplicationModel.Resources;
 using Windows.Security.Credentials.UI;
 using Windows.System;
 using Windows.UI.Xaml;
@@ -16,20 +15,22 @@ namespace Unicord.Universal.Pages.Settings
         {
             InitializeComponent();
             DataContext = new SecuritySettingsModel();
-            MarkdownDocument.KnownSchemes.Add("ms-settings");
         }
 
         private async void Page_Loaded(object sender, RoutedEventArgs e)
         {
+            var resources = ResourceLoader.GetForCurrentView("SecuritySettingsPage");
+            unavailableText.Title = resources.GetString("WindowsHelloUnavailable/Text");
+            
             var available = await UserConsentVerifier.CheckAvailabilityAsync();
             if (available != UserConsentVerifierAvailability.Available)
             {
-                unavailableText.Visibility = Visibility.Visible;
+                unavailableText.IsOpen = true;
                 settingsContent.IsEnabled = false;
             }
             else
             {
-                unavailableText.Visibility = Visibility.Collapsed;
+                unavailableText.IsOpen = false;
                 settingsContent.IsEnabled = true;
             }
         }
@@ -39,9 +40,9 @@ namespace Unicord.Universal.Pages.Settings
             await AppCenter.SetEnabledAsync((sender as ToggleSwitch).IsOn);
         }
 
-        private async void unavailableText_LinkClicked(object sender, LinkClickedEventArgs e)
+        private async void OpenSettingsButton_Click(object sender, RoutedEventArgs e)
         {
-            await Launcher.LaunchUriAsync(new Uri(e.Link));
+            await Launcher.LaunchUriAsync(new Uri("ms-settings:privacy-deviceencryption"));
         }
     }
 }

--- a/Unicord.Universal/Pages/Settings/SettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/SettingsPage.xaml
@@ -51,11 +51,13 @@
                                           Width="24"
                                           Height="24"
                                           Margin="10,8,10,8"
-                                          HorizontalAlignment="Center"/>
+                                          HorizontalAlignment="Center"
+                                          ProfilePicture="{Binding ProfileAvatarUrl}"/>
                         <StackPanel x:Name="ProfileDetails" Grid.Column="1" VerticalAlignment="Center" Margin="0,8,16,8">
                             <TextBlock x:Name="UserDisplayName"
                                       FontWeight="SemiBold"
-                                      TextTrimming="CharacterEllipsis"/>
+                                      TextTrimming="CharacterEllipsis"
+                                      Text="{Binding ProfileDisplayName}"/>
                             <TextBlock x:Uid="/SettingsPage/EditProfileText"
                                       Text="Edit Profiles"
                                       FontSize="12"

--- a/Unicord.Universal/Pages/Settings/SettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/SettingsPage.xaml
@@ -25,12 +25,86 @@
                             IsSettingsVisible="False"
                             IsBackEnabled="True"
                             BackRequested="NavView_BackRequested"
-                            SelectionChanged="NavView_SelectionChanged">
+                            SelectionChanged="NavView_SelectionChanged"
+                            DisplayModeChanged="NavView_DisplayModeChanged"
+                            PaneOpening="NavView_PaneOpening"
+                            PaneOpened="NavView_PaneOpened"
+                            PaneClosing="NavView_PaneClosing">
             <lib:NavigationView.Resources>
                 <StaticResource x:Key="NavigationViewContentBackground" ResourceKey="LayerFillColorAltBrush" />
             </lib:NavigationView.Resources>
 
             <lib:NavigationView.MenuItems>
+                <lib:NavigationViewItem x:Name="ProfileItem"
+                                        SelectsOnInvoked="False"
+                                        IsTabStop="True"
+                                        Tapped="ProfileItem_Tapped"
+                                        HorizontalContentAlignment="Stretch"
+                                        Padding="0"
+                                        Margin="0">
+                    <Grid x:Name="ProfileContainer">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <lib:PersonPicture x:Name="UserProfilePicture"
+                                          Width="24"
+                                          Height="24"
+                                          Margin="10,8,10,8"
+                                          HorizontalAlignment="Center"/>
+                        <StackPanel x:Name="ProfileDetails" Grid.Column="1" VerticalAlignment="Center" Margin="0,8,16,8">
+                            <TextBlock x:Name="UserDisplayName"
+                                      FontWeight="SemiBold"
+                                      TextTrimming="CharacterEllipsis"/>
+                            <TextBlock x:Uid="/SettingsPage/EditProfileText"
+                                      Text="Edit Profiles"
+                                      FontSize="12"
+                                      Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                      TextTrimming="CharacterEllipsis"/>
+                        </StackPanel>
+                    </Grid>
+                </lib:NavigationViewItem>
+
+                <lib:NavigationViewItem x:Name="SearchItem"
+                                        SelectsOnInvoked="False"
+                                        IsTabStop="False"
+                                        Tapped="SearchItem_Tapped"
+                                        HorizontalContentAlignment="Stretch"
+                                        Padding="0"
+                                        Margin="0">
+                    <lib:NavigationViewItem.Resources>
+                        <x:Double x:Key="NavigationViewCompactPaneLength">0</x:Double>
+                        <Thickness x:Key="NavigationViewItemOnLeftIconBoxMargin">0</Thickness>
+                        <Thickness x:Key="NavigationViewItemContentPresenterMargin">0</Thickness>
+                        <Thickness x:Key="NavigationViewCompactItemContentPresenterMargin">0</Thickness>
+                    </lib:NavigationViewItem.Resources>
+                    <Grid HorizontalAlignment="Stretch">
+                        <!-- Full search box for expanded mode -->
+                        <Grid x:Name="SearchBoxContainer" HorizontalAlignment="Stretch" Margin="0">
+                            <AutoSuggestBox x:Name="SearchBox"
+                                           x:Uid="/SettingsPage/SearchBox"
+                                           PlaceholderText="Search"
+                                           QueryIcon="Find"
+                                           Margin="0"
+                                           Padding="0"
+                                           HorizontalAlignment="Stretch"
+                                           IsHitTestVisible="True"
+                                           TextChanged="SearchBox_TextChanged"
+                                           QuerySubmitted="SearchBox_QuerySubmitted"/>
+                        </Grid>
+                        <!-- Search icon for compact mode (NavigationViewItem provides the background/visual states) -->
+                        <Grid x:Name="SearchIconContainer"
+                              Visibility="Collapsed"
+                              Width="40"
+                              Height="40"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Center"
+                              IsHitTestVisible="False">
+                            <FontIcon Glyph="&#xE721;" FontSize="16" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0"/>
+                        </Grid>
+                    </Grid>
+                </lib:NavigationViewItem>
+
                 <lib:NavigationViewItem Tag="Accounts" x:Uid="/SettingsPage/AccountsItem">
                     <lib:NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE910;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
@@ -45,7 +119,7 @@
 
                 <lib:NavigationViewItem Tag="Notifications" x:Uid="/SettingsPage/NotificationsItem">
                     <lib:NavigationViewItem.Icon>
-                        <FontIcon Glyph="&#xE91C;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                        <FontIcon Glyph="{Binding NotificationIconGlyph}" FontFamily="{StaticResource SymbolThemeFontFamily}" />
                     </lib:NavigationViewItem.Icon>
                 </lib:NavigationViewItem>
 
@@ -83,8 +157,8 @@
                 </lib:NavigationViewItem>
             </lib:NavigationView.FooterMenuItems>
             
-            <ScrollViewer Margin="20">
-                <Frame x:Name="MainFrame" />
+            <ScrollViewer Margin="20,20,0,0">
+                <Frame x:Name="MainFrame" Margin="0,0,20,12" />
             </ScrollViewer>
         </lib:NavigationView>
 

--- a/Unicord.Universal/Pages/Settings/SettingsPage.xaml.cs
+++ b/Unicord.Universal/Pages/Settings/SettingsPage.xaml.cs
@@ -209,8 +209,7 @@ namespace Unicord.Universal.Pages.Settings
 
         private void UpdateSearchDisplayMode()
         {
-            // We want icon-only UI when the pane is collapsed via the hamburger.
-            // Note: DisplayMode may still be Expanded when the pane is closed.
+            // Icon-only UI when the pane is collapsed via the hamburger.
             var paneOpen = NavView.IsPaneOpen;
             var paneOpening = _isPaneOpening && !paneOpen;
             var showCompact = !paneOpen && !paneOpening;
@@ -230,13 +229,11 @@ namespace Unicord.Universal.Pages.Settings
                 ProfileDetails.Visibility = Visibility.Collapsed;
                 ProfileItem.Visibility = Visibility.Visible;
 
-                // Keep compact icons aligned with the theme's default nav icons.
-                // SunValley already matches; Fluent/Performance need a slight left nudge.
+                // Top (Sun Valley) Bottom (Fluent/Performance)
                 SearchIconContainer.Margin = theme == AppTheme.SunValley
                     ? new Thickness(-8, 0, 0, 0)
                     : new Thickness(-16, 0, 0, 0);
                 
-                // Compact pane: center avatar inside the full row (avoid large right-side empty space)
                 Grid.SetColumnSpan(UserProfilePicture, 2);
                 UserProfilePicture.HorizontalAlignment = HorizontalAlignment.Center;
                 UserProfilePicture.Width = 24;
@@ -302,7 +299,7 @@ namespace Unicord.Universal.Pages.Settings
             switch (theme)
             {
                 case AppTheme.SunValley:
-                    // SunValley uses different NavigationView paddings; keep the tuned layout.
+                    // SunValley
                     SearchBoxContainer.Margin = new Thickness(0, 0, -6.5, 0);
                     ProfileContainer.Margin = new Thickness(0);
                     break;
@@ -310,7 +307,7 @@ namespace Unicord.Universal.Pages.Settings
                 case AppTheme.Fluent:
                 case AppTheme.Performance:
                 default:
-                    // Win10-era NavigationView has more built-in insets; reintroduce them for the special rows.
+                    // Fluent/Performance
                     SearchBoxContainer.Margin = new Thickness(-5, 0, 11, 0);
                     ProfileContainer.Margin = new Thickness(-5, 0, 11, 0);
                     break;
@@ -350,7 +347,6 @@ namespace Unicord.Universal.Pages.Settings
 
         private void ProfileItem_Tapped(object sender, TappedRoutedEventArgs e)
         {
-            // Clicking the profile row should not keep the AutoSuggestBox focused/selected.
             if (SearchBox != null)
             {
                 SearchBox.IsSuggestionListOpen = false;

--- a/Unicord.Universal/Pages/Settings/SettingsPage.xaml.cs
+++ b/Unicord.Universal/Pages/Settings/SettingsPage.xaml.cs
@@ -4,10 +4,14 @@ using System.Linq;
 using Unicord.Universal.Services;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
+using Windows.UI;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
+using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Navigation;
 using Lib = Microsoft.UI.Xaml.Controls;
 
@@ -21,6 +25,10 @@ namespace Unicord.Universal.Pages.Settings
 
     public sealed partial class SettingsPage : Page, IOverlay
     {
+        private long _isPaneOpenCallbackToken;
+        private bool _isPaneOpening;
+        private bool _focusSearchOnNextPaneOpened;
+
         // these should be kept in order as they appear in the UI,
         // and in sync with Unicord.Universal.Services.SettingsPage
         private static Dictionary<SettingsPageType, Type> _pages
@@ -47,18 +55,53 @@ namespace Unicord.Universal.Pages.Settings
         public SettingsPage()
         {
             InitializeComponent();
-            NavView.SelectedItem = NavView.MenuItems[0];
+            SelectNavItem(SettingsPageType.Accounts);
+            
+            // Load user info
+            var user = DiscordManager.Discord?.CurrentUser;
+            if (user != null)
+            {
+                UserDisplayName.Text = user.GlobalName ?? user.Username;
+                if (!string.IsNullOrEmpty(user.AvatarUrl))
+                {
+                    UserProfilePicture.ProfilePicture = new BitmapImage(new Uri(user.AvatarUrl));
+                }
+            }
+
+            // Set initial display mode state
+            Loaded += (s, e) =>
+            {
+                if (_isPaneOpenCallbackToken == 0)
+                {
+                    _isPaneOpenCallbackToken = NavView.RegisterPropertyChangedCallback(
+                        Lib.NavigationView.IsPaneOpenProperty,
+                        (_, __) => UpdateSearchDisplayMode());
+                }
+
+                UpdateSearchDisplayMode();
+            };
+        }
+
+        private void SelectNavItem(SettingsPageType pageType)
+        {
+            if (NavView == null)
+                return;
+
+            var tag = pageType.ToString();
+            var item = NavView.MenuItems
+                .Concat(NavView.FooterMenuItems)
+                .OfType<Lib.NavigationViewItem>()
+                .FirstOrDefault(i => string.Equals(i.Tag?.ToString(), tag, StringComparison.OrdinalIgnoreCase));
+
+            if (item != null)
+                NavView.SelectedItem = item;
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             if (e.Parameter is SettingsPageType t)
             {
-                if (_pages.TryGetValue(t, out var type))
-                {
-                    var newIndex = _pages.Keys.ToList().IndexOf(t);
-                    NavView.SelectedItem = NavView.MenuItems.Concat(NavView.FooterMenuItems).ElementAt(newIndex);
-                }
+                SelectNavItem(t);
             }
 
             var manager = SystemNavigationManager.GetForCurrentView();
@@ -69,6 +112,12 @@ namespace Unicord.Universal.Pages.Settings
         {
             var manager = SystemNavigationManager.GetForCurrentView();
             manager.BackRequested -= OnBackRequested;
+
+            if (_isPaneOpenCallbackToken != 0)
+            {
+                NavView.UnregisterPropertyChangedCallback(Lib.NavigationView.IsPaneOpenProperty, _isPaneOpenCallbackToken);
+                _isPaneOpenCallbackToken = 0;
+            }
 
             MainFrame.Navigate(typeof(Page));
         }
@@ -119,6 +168,268 @@ namespace Unicord.Universal.Pages.Settings
             }
 
             MainFrame.Navigate(type, transitionInfo);
+        }
+
+        private void NavView_DisplayModeChanged(Lib.NavigationView sender, Lib.NavigationViewDisplayModeChangedEventArgs args)
+        {
+            UpdateSearchDisplayMode();
+        }
+
+        private void NavView_PaneOpening(Lib.NavigationView sender, object args)
+        {
+            // Hide compact UI immediately when opening begins.
+            // Also request focus for the search box once opening completes.
+            if (SearchIconContainer?.Visibility == Visibility.Visible)
+                _focusSearchOnNextPaneOpened = true;
+
+            _isPaneOpening = true;
+            UpdateSearchDisplayMode();
+        }
+
+        private void NavView_PaneOpened(Lib.NavigationView sender, object args)
+        {
+            _isPaneOpening = false;
+            UpdateSearchDisplayMode();
+
+            if (_focusSearchOnNextPaneOpened)
+            {
+                _focusSearchOnNextPaneOpened = false;
+                _ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                {
+                    SearchBox?.Focus(FocusState.Programmatic);
+                });
+            }
+        }
+
+        private void NavView_PaneClosing(Lib.NavigationView sender, Lib.NavigationViewPaneClosingEventArgs args)
+        {
+            _isPaneOpening = false;
+            UpdateSearchDisplayMode();
+        }
+
+        private void UpdateSearchDisplayMode()
+        {
+            // Note: DisplayMode may still be Expanded when the pane is closed.
+            var paneOpen = NavView.IsPaneOpen;
+            var paneOpening = _isPaneOpening && !paneOpen;
+            var showCompact = !paneOpen && !paneOpening;
+
+            var theme = ThemeService.GetForCurrentView().GetTheme();
+
+            UpdateSpecialRowMargins(paneOpen, paneOpening);
+
+            // Suppress NavigationViewItem hover highlight only when the full search box is visible.
+            SetSearchRowHighlightSuppressed(paneOpen);
+
+            if (showCompact)
+            {
+                // Pane closed: show icons only
+                SearchBoxContainer.Visibility = Visibility.Collapsed;
+                SearchIconContainer.Visibility = Visibility.Visible;
+                ProfileDetails.Visibility = Visibility.Collapsed;
+                ProfileItem.Visibility = Visibility.Visible;
+
+                // Keep compact icons aligned with the theme's default nav icons.
+                // SunValley already matches; Fluent/Performance need a slight left nudge.
+                SearchIconContainer.Margin = theme == AppTheme.SunValley
+                    ? new Thickness(0)
+                    : new Thickness(-16, 0, 0, 0);
+                
+                // Compact pane: center avatar inside the full row (avoid large right-side empty space)
+                Grid.SetColumnSpan(UserProfilePicture, 2);
+                UserProfilePicture.HorizontalAlignment = HorizontalAlignment.Center;
+                UserProfilePicture.Width = 24;
+                UserProfilePicture.Height = 24;
+                UserProfilePicture.Margin = theme == AppTheme.SunValley
+                    ? new Thickness(-8, 8, 0, 8)
+                    : new Thickness(-16, 8, 0, 8);
+            }
+            else if (paneOpening)
+            {
+                // Pane is animating open: hide compact icon immediately so it doesn't linger.
+                // The full search box will appear once the pane is actually open.
+                SearchBoxContainer.Visibility = Visibility.Collapsed;
+                SearchIconContainer.Visibility = Visibility.Collapsed;
+                ProfileDetails.Visibility = Visibility.Collapsed;
+                ProfileItem.Visibility = Visibility.Visible;
+
+                SearchIconContainer.Margin = theme == AppTheme.SunValley
+                    ? new Thickness(0)
+                    : new Thickness(-4, 0, 0, 0);
+                
+                Grid.SetColumnSpan(UserProfilePicture, 2);
+                UserProfilePicture.HorizontalAlignment = HorizontalAlignment.Center;
+                UserProfilePicture.Width = 24;
+                UserProfilePicture.Height = 24;
+                UserProfilePicture.Margin = theme == AppTheme.SunValley
+                    ? new Thickness(-3, 8, 0, 8)
+                    : new Thickness(-4, 8, 0, 8);
+            }
+            else
+            {
+                // Pane open: show full UI
+                SearchBoxContainer.Visibility = Visibility.Visible;
+                SearchIconContainer.Visibility = Visibility.Collapsed;
+                ProfileDetails.Visibility = Visibility.Visible;
+                ProfileItem.Visibility = Visibility.Visible;
+
+                SearchIconContainer.Margin = new Thickness(0);
+                
+                // Left align avatar in expanded mode and restore normal size
+                Grid.SetColumnSpan(UserProfilePicture, 1);
+                UserProfilePicture.HorizontalAlignment = HorizontalAlignment.Left;
+                UserProfilePicture.Width = 48;
+                UserProfilePicture.Height = 48;
+                UserProfilePicture.Margin = new Thickness(5, 8, 10, 8);
+            }
+        }
+
+        private void UpdateSpecialRowMargins(bool paneOpen, bool paneOpening)
+        {
+            if (SearchBoxContainer == null || ProfileContainer == null)
+                return;
+
+            // Never apply insets in compact/pane-opening states; it would offset the centered icons.
+            if (!paneOpen || paneOpening)
+            {
+                SearchBoxContainer.Margin = new Thickness(0);
+                ProfileContainer.Margin = new Thickness(0);
+                return;
+            }
+
+            var theme = ThemeService.GetForCurrentView().GetTheme();
+            switch (theme)
+            {
+                case AppTheme.SunValley:
+                    // SunValley uses different NavigationView paddings; keep the tuned layout.
+                    SearchBoxContainer.Margin = new Thickness(0, 0, -6.5, 0);
+                    ProfileContainer.Margin = new Thickness(0);
+                    break;
+
+                case AppTheme.Fluent:
+                case AppTheme.Performance:
+                default:
+                    // Win10-era NavigationView has more built-in insets; reintroduce them for the special rows.
+                    SearchBoxContainer.Margin = new Thickness(-5, 0, 11, 0);
+                    ProfileContainer.Margin = new Thickness(-5, 0, 11, 0);
+                    break;
+            }
+        }
+
+        private void SetSearchRowHighlightSuppressed(bool suppress)
+        {
+            if (SearchItem == null)
+                return;
+
+            var keys = new[]
+            {
+                "NavigationViewItemBackgroundPointerOver",
+                "NavigationViewItemBackgroundPressed",
+                "NavigationViewItemBackgroundCheckedPointerOver",
+                "NavigationViewItemBackgroundCheckedPressed",
+                "NavigationViewItemBackgroundSelectedPointerOver",
+                "NavigationViewItemBackgroundSelectedPressed",
+            };
+
+            if (suppress)
+            {
+                var transparent = new SolidColorBrush(Colors.Transparent);
+                foreach (var key in keys)
+                    SearchItem.Resources[key] = transparent;
+            }
+            else
+            {
+                foreach (var key in keys)
+                {
+                    if (SearchItem.Resources.ContainsKey(key))
+                        SearchItem.Resources.Remove(key);
+                }
+            }
+        }
+
+        private void ProfileItem_Tapped(object sender, TappedRoutedEventArgs e)
+        {
+            // Clicking the profile row should not keep the AutoSuggestBox focused/selected.
+            if (SearchBox != null)
+            {
+                SearchBox.IsSuggestionListOpen = false;
+            }
+
+            if (sender is Control c)
+                c.Focus(FocusState.Pointer);
+            else
+                NavView?.Focus(FocusState.Pointer);
+
+            e.Handled = true;
+        }
+
+        private void SearchItem_Tapped(object sender, TappedRoutedEventArgs e)
+        {
+            // Only meaningful when pane is closed (compact/icon mode).
+            if (NavView?.IsPaneOpen == true || SearchIconContainer?.Visibility != Visibility.Visible)
+                return;
+
+            // Immediately show full UI and focus search box
+            SearchBoxContainer.Visibility = Visibility.Visible;
+            SearchIconContainer.Visibility = Visibility.Collapsed;
+            ProfileDetails.Visibility = Visibility.Visible;
+            
+            // Suppress NavigationViewItem hover highlight immediately
+            SetSearchRowHighlightSuppressed(true);
+            
+            // Force clear any pressed/selected visual state on SearchItem
+            SearchItem.IsEnabled = false;
+            SearchItem.IsEnabled = true;
+            
+            SearchBox.Focus(FocusState.Programmatic);
+            
+            NavView.IsPaneOpen = true;
+            e.Handled = true;
+        }
+
+        private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+        {
+            if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
+            {
+                var searchTerm = sender.Text.ToLower();
+                if (string.IsNullOrWhiteSpace(searchTerm))
+                {
+                    sender.ItemsSource = null;
+                    return;
+                }
+
+                // Search through navigation items (skip items without tags)
+                var results = new List<Lib.NavigationViewItem>();
+                foreach (var item in NavView.MenuItems.Concat(NavView.FooterMenuItems).OfType<Lib.NavigationViewItem>())
+                {
+                    if (item.Tag == null) continue; // Skip profile/search items
+                    
+                    var content = item.Content?.ToString()?.ToLower() ?? "";
+                    if (content.Contains(searchTerm))
+                    {
+                        results.Add(item);
+                    }
+                }
+
+                sender.ItemsSource = results.Select(r => r.Content).ToList();
+            }
+        }
+
+        private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+        {
+            if (args.ChosenSuggestion != null || !string.IsNullOrWhiteSpace(args.QueryText))
+            {
+                var searchText = (args.ChosenSuggestion?.ToString() ?? args.QueryText).ToLower();
+                var item = NavView.MenuItems.Concat(NavView.FooterMenuItems)
+                    .OfType<Lib.NavigationViewItem>()
+                    .Where(i => i.Tag != null) // Skip profile/search items
+                    .FirstOrDefault(i => i.Content?.ToString()?.ToLower() == searchText);
+
+                if (item != null)
+                {
+                    NavView.SelectedItem = item;
+                }
+            }
         }
     }
 }

--- a/Unicord.Universal/Pages/Settings/SettingsPage.xaml.cs
+++ b/Unicord.Universal/Pages/Settings/SettingsPage.xaml.cs
@@ -209,6 +209,7 @@ namespace Unicord.Universal.Pages.Settings
 
         private void UpdateSearchDisplayMode()
         {
+            // We want icon-only UI when the pane is collapsed via the hamburger.
             // Note: DisplayMode may still be Expanded when the pane is closed.
             var paneOpen = NavView.IsPaneOpen;
             var paneOpening = _isPaneOpening && !paneOpen;
@@ -232,7 +233,7 @@ namespace Unicord.Universal.Pages.Settings
                 // Keep compact icons aligned with the theme's default nav icons.
                 // SunValley already matches; Fluent/Performance need a slight left nudge.
                 SearchIconContainer.Margin = theme == AppTheme.SunValley
-                    ? new Thickness(0)
+                    ? new Thickness(-8, 0, 0, 0)
                     : new Thickness(-16, 0, 0, 0);
                 
                 // Compact pane: center avatar inside the full row (avoid large right-side empty space)

--- a/Unicord.Universal/Pages/Settings/SettingsPage.xaml.cs
+++ b/Unicord.Universal/Pages/Settings/SettingsPage.xaml.cs
@@ -56,17 +56,6 @@ namespace Unicord.Universal.Pages.Settings
         {
             InitializeComponent();
             SelectNavItem(SettingsPageType.Accounts);
-            
-            // Load user info
-            var user = DiscordManager.Discord?.CurrentUser;
-            if (user != null)
-            {
-                UserDisplayName.Text = user.GlobalName ?? user.Username;
-                if (!string.IsNullOrEmpty(user.AvatarUrl))
-                {
-                    UserProfilePicture.ProfilePicture = new BitmapImage(new Uri(user.AvatarUrl));
-                }
-            }
 
             // Set initial display mode state
             Loaded += (s, e) =>

--- a/Unicord.Universal/Pages/Settings/ThemesSettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/ThemesSettingsPage.xaml
@@ -19,7 +19,7 @@
 
     <StackPanel>
 
-        <Border Padding="8" 
+        <!--<Border Padding="8" 
                 Margin="0,0,0,8"
                 BorderBrush="{ThemeResource SystemFillColorCautionBackground}"
                 BorderThickness="1"
@@ -38,7 +38,7 @@
                 <TextBlock x:Uid="/ThemesSettingsPage/RelaunchRequired"
                            VerticalAlignment="Center"/>
             </StackPanel>
-        </Border>
+        </Border>-->
 
         <settings:SettingsBlockControl x:Uid="/ThemesSettingsPage/ColourSchemeBlock">
             <settings:SettingsBlockControl.Icon>

--- a/Unicord.Universal/Pages/Settings/ThemesSettingsPage.xaml.cs
+++ b/Unicord.Universal/Pages/Settings/ThemesSettingsPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Unicord.Universal.Models;
 using Unicord.Universal.Utilities;
 using Windows.ApplicationModel.Core;
@@ -15,40 +16,78 @@ namespace Unicord.Universal.Pages.Settings
         private int _initialColour;
         private bool _loaded;
         private bool _dragging;
+        private bool _restartPromptShown;
 
         public ThemesSettingsPage()
         {
             InitializeComponent();
         }
 
-        protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
+        protected override async void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
-            OnClosing();
+            await OnClosingAsync();
         }
 
-        private void ColorSchemeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        private async void ColorSchemeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            ((ThemesSettingsModel)DataContext).ColourScheme = ((ComboBox)sender).SelectedIndex;
+            var comboBox = (ComboBox)sender;
+            var previousIndex = e.RemovedItems.Count > 0 ? ((ComboBox)sender).Items.IndexOf(e.RemovedItems[0]) : comboBox.SelectedIndex;
+            
+            ((ThemesSettingsModel)DataContext).ColourScheme = comboBox.SelectedIndex;
+            
+            if (!await OnClosingAsync())
+            {
+                // User clicked Cancel, revert the selection
+                comboBox.SelectionChanged -= ColorSchemeComboBox_SelectionChanged;
+                comboBox.SelectedIndex = previousIndex;
+                ((ThemesSettingsModel)DataContext).ColourScheme = previousIndex;
+                comboBox.SelectionChanged += ColorSchemeComboBox_SelectionChanged;
+            }
         }
 
-        private void ApplicationThemeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        private async void ApplicationThemeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            ((ThemesSettingsModel)DataContext).ApplicationTheme = ((ComboBox)sender).SelectedIndex;
+            var comboBox = (ComboBox)sender;
+            var previousIndex = e.RemovedItems.Count > 0 ? ((ComboBox)sender).Items.IndexOf(e.RemovedItems[0]) : comboBox.SelectedIndex;
+            
+            ((ThemesSettingsModel)DataContext).ApplicationTheme = comboBox.SelectedIndex;
+            
+            if (!await OnClosingAsync())
+            {
+                // User clicked Cancel, revert the selection
+                comboBox.SelectionChanged -= ApplicationThemeComboBox_SelectionChanged;
+                comboBox.SelectedIndex = previousIndex;
+                ((ThemesSettingsModel)DataContext).ApplicationTheme = previousIndex;
+                comboBox.SelectionChanged += ApplicationThemeComboBox_SelectionChanged;
+            }
         }
 
-        public async void OnClosing()
+        public async Task<bool> OnClosingAsync()
         {
-            if (!((ThemesSettingsModel)DataContext).IsDirty)
-                return;
+            if (!((ThemesSettingsModel)DataContext).IsDirty || _restartPromptShown)
+                return true;
 
             if (ApiInformation.IsMethodPresent("Windows.ApplicationModel.Core.CoreApplication", "RequestRestartAsync"))
             {
+                _restartPromptShown = true;
                 var resources = ResourceLoader.GetForCurrentView("ThemesSettingsPage");
                 if (await UIUtilities.ShowYesNoDialogAsync(resources.GetString("ThemeChangedTitle"), resources.GetString("ThemeChangedMessage")))
                 {
                     await CoreApplication.RequestRestartAsync("");
+                    return true;
+                }
+                else
+                {
+                    _restartPromptShown = false;
+                    return false;
                 }
             }
+            return true;
+        }
+
+        public async void OnClosing()
+        {
+            await OnClosingAsync();
         }
     }
 }

--- a/Unicord.Universal/Resources/en-GB/AccountsSettingsPage.resw
+++ b/Unicord.Universal/Resources/en-GB/AccountsSettingsPage.resw
@@ -120,8 +120,11 @@
   <data name="AccountsSettingsPage.Tag" xml:space="preserve">
     <value>Accounts</value>
   </data>
-  <data name="BackgroundNotificationsBlock.Description" xml:space="preserve">
+  <data name="BackgroundNotificationsDescriptionWin10" xml:space="preserve">
     <value>Allow Unicord to run in the background to show notifications &amp; update live tiles.</value>
+  </data>
+  <data name="BackgroundNotificationsDescriptionWin11" xml:space="preserve">
+    <value>Allow Unicord to run in the background to show notifications.</value>
   </data>
   <data name="BackgroundNotificationsBlock.Title" xml:space="preserve">
     <value>Background Notifications</value>
@@ -144,6 +147,9 @@
   <data name="LogoutBlock.Title" xml:space="preserve">
     <value>Log out</value>
   </data>
+  <data name="LogoutButton.Content" xml:space="preserve">
+    <value>Log out</value>
+  </data>
   <data name="LogoutPromptMessage" xml:space="preserve">
     <value>Are you sure you want to logout?</value>
   </data>
@@ -152,6 +158,18 @@
   </data>
   <data name="StatisticsText.Text" xml:space="preserve">
     <value>Statistics</value>
+  </data>
+  <data name="StatisticsBlock.Title" xml:space="preserve">
+    <value>Statistics</value>
+  </data>
+  <data name="StatisticsBlock.Description" xml:space="preserve">
+    <value>View detailed statistics about your account</value>
+  </data>
+  <data name="CopyStatisticsButton.Content" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="CopyStatisticsButtonText.Text" xml:space="preserve">
+    <value>Copy</value>
   </data>
   <data name="SyncContactsBlock.Description" xml:space="preserve">
     <value>Sync your Discord friends with the People app.</value>

--- a/Unicord.Universal/Resources/en-GB/Dialogs.resw
+++ b/Unicord.Universal/Resources/en-GB/Dialogs.resw
@@ -157,7 +157,7 @@
     <value>Yes</value>
   </data>
   <data name="ConfirmationDialog.SecondaryButtonText" xml:space="preserve">
-    <value>No</value>
+    <value>Cancel</value>
   </data>
   <data name="DeleteMessageDialog.PrimaryButtonText" xml:space="preserve">
     <value>Yeah!</value>

--- a/Unicord.Universal/Resources/en-GB/MessagingSettingsPage.resw
+++ b/Unicord.Universal/Resources/en-GB/MessagingSettingsPage.resw
@@ -133,7 +133,7 @@
     <value>Hide Spoilered Content</value>
   </data>
   <data name="LearnMoreButton.Content" xml:space="preserve">
-    <value>Learn More</value>
+    <value>More about contrast</value>
   </data>
   <data name="MessagingSettingsHeader.Text" xml:space="preserve">
     <value>Text and Images</value>

--- a/Unicord.Universal/Resources/en-GB/NotificationsSettingsPage.resw
+++ b/Unicord.Universal/Resources/en-GB/NotificationsSettingsPage.resw
@@ -133,7 +133,7 @@
     <value>Enable Unread Badge</value>
   </data>
   <data name="EnableDesktopNotifications.Description" xml:space="preserve">
-    <value>Show notifications for Mentions and Direct Messages in on the Desktop, and in Action Centre</value>
+    <value>Show notifications for Mentions and Direct Messages on the Desktop and in Notification Center</value>
   </data>
   <data name="EnableDesktopNotifications.Title" xml:space="preserve">
     <value>Enable Desktop Notifications</value>
@@ -144,10 +144,19 @@
   <data name="EnableLiveTiles.Title" xml:space="preserve">
     <value>Enable Live Tiles</value>
   </data>
-  <data name="EnableNotifications.Description" xml:space="preserve">
-    <value>Show notifications for Discord messages in Start, Action Centre and the Taskbar</value>
+  <data name="EnableNotificationsDescriptionWin10" xml:space="preserve">
+    <value>Show notifications for Discord messages in Start, Action Centre, and the Taskbar</value>
+  </data>
+  <data name="EnableNotificationsDescriptionWin11" xml:space="preserve">
+    <value>Show notifications for Discord messages in Notification Center and on the Taskbar</value>
   </data>
   <data name="EnableNotifications.Title" xml:space="preserve">
     <value>Enable Notifications</value>
+  </data>
+  <data name="EnableDesktopNotificationsDescriptionWin10" xml:space="preserve">
+    <value>Show notifications for Mentions and Direct Messages on the Desktop and in Action Centre</value>
+  </data>
+  <data name="EnableDesktopNotificationsDescriptionWin11" xml:space="preserve">
+    <value>Show notifications for Mentions and Direct Messages on the Desktop and in Notification Center</value>
   </data>
 </root>

--- a/Unicord.Universal/Resources/en-GB/SecuritySettingsPage.resw
+++ b/Unicord.Universal/Resources/en-GB/SecuritySettingsPage.resw
@@ -151,6 +151,9 @@
     <value />
   </data>
   <data name="WindowsHelloUnavailable.Text" xml:space="preserve">
-    <value>Windows Hello is not available on this device. Wanna [change that?](ms-settings:signinoptions)</value>
+    <value>Windows Hello is not available on this device. Wanna change that?</value>
+  </data>
+  <data name="OpenSettingsButton.Content" xml:space="preserve">
+    <value>Open Settings</value>
   </data>
 </root>

--- a/Unicord.Universal/Resources/en-GB/SettingsPage.resw
+++ b/Unicord.Universal/Resources/en-GB/SettingsPage.resw
@@ -141,4 +141,10 @@
   <data name="VoiceItem.Content" xml:space="preserve">
     <value>Voice Calls</value>
   </data>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Search</value>
+  </data>
+  <data name="EditProfileText.Text" xml:space="preserve">
+    <value>Edit Profiles</value>
+  </data>
 </root>

--- a/Unicord.Universal/Resources/en-US/AccountsSettingsPage.resw
+++ b/Unicord.Universal/Resources/en-US/AccountsSettingsPage.resw
@@ -138,6 +138,18 @@
   <data name="StatisticsText.Text" xml:space="preserve">
     <value>Statistics</value>
   </data>
+  <data name="StatisticsBlock.Title" xml:space="preserve">
+    <value>Statistics</value>
+  </data>
+  <data name="StatisticsBlock.Description" xml:space="preserve">
+    <value>View detailed statistics about your account</value>
+  </data>
+  <data name="CopyStatisticsButton.Content" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="CopyStatisticsButtonText.Text" xml:space="preserve">
+    <value>Copy</value>
+  </data>
   <data name="SyncPeopleText.Text" xml:space="preserve">
     <value>Sync my friends with [Windows People](ms-people:)</value>
     <comment>Markdown capable</comment>

--- a/Unicord.Universal/Resources/en-US/Dialogs.resw
+++ b/Unicord.Universal/Resources/en-US/Dialogs.resw
@@ -157,7 +157,7 @@
     <value>Yes</value>
   </data>
   <data name="ConfirmationDialog.SecondaryButtonText" xml:space="preserve">
-    <value>No</value>
+    <value>Cancel</value>
   </data>
   <data name="DeleteMessageDialog.PrimaryButtonText" xml:space="preserve">
     <value>Yeah!</value>

--- a/Unicord.Universal/Resources/en-US/MessagingSettingsPage.resw
+++ b/Unicord.Universal/Resources/en-US/MessagingSettingsPage.resw
@@ -133,7 +133,7 @@
     <value>Enable Spoilers</value>
   </data>
   <data name="LearnMoreButton.Content" xml:space="preserve">
-    <value>Learn More</value>
+    <value>More about contrast</value>
   </data>
   <data name="MessagingSettingsHeader.Text" xml:space="preserve">
     <value>Text and Images</value>

--- a/Unicord.Universal/Resources/en-US/SecuritySettingsPage.resw
+++ b/Unicord.Universal/Resources/en-US/SecuritySettingsPage.resw
@@ -148,6 +148,9 @@
     <value />
   </data>
   <data name="WindowsHelloUnavailable.Text" xml:space="preserve">
-    <value>Windows Hello is not available on this device. Wanna [change that?](ms-settings:signinoptions)</value>
+    <value>Windows Hello is not available on this device. Wanna change that?</value>
+  </data>
+  <data name="OpenSettingsButton.Content" xml:space="preserve">
+    <value>Open Settings</value>
   </data>
 </root>

--- a/Unicord.Universal/Resources/en-US/SettingsPage.resw
+++ b/Unicord.Universal/Resources/en-US/SettingsPage.resw
@@ -138,4 +138,10 @@
   <data name="VoiceItem.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Voice</value>
   </data>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Search</value>
+  </data>
+  <data name="EditProfileText.Text" xml:space="preserve">
+    <value>Edit Profiles</value>
+  </data>
 </root>

--- a/Unicord.Universal/Resources/fr/AccountsSettingsPage.resw
+++ b/Unicord.Universal/Resources/fr/AccountsSettingsPage.resw
@@ -132,6 +132,21 @@
   <data name="LogoutPromptTitle" xml:space="preserve">
     <value>Êtes-vous sûr?</value>
   </data>
+  <data name="StatisticsText.Text" xml:space="preserve">
+    <value>Statistiques</value>
+  </data>
+  <data name="StatisticsBlock.Title" xml:space="preserve">
+    <value>Statistiques</value>
+  </data>
+  <data name="StatisticsBlock.Description" xml:space="preserve">
+    <value>Voir les statistiques détaillées de votre compte</value>
+  </data>
+  <data name="CopyStatisticsButton.Content" xml:space="preserve">
+    <value>Copier</value>
+  </data>
+  <data name="CopyStatisticsButtonText.Text" xml:space="preserve">
+    <value>Copier</value>
+  </data>
   <data name="SyncPeopleText.Text" xml:space="preserve">
     <value>Synchroniser mes amis avec [Windows People](ms-people:)</value>
     <comment>Markdown capable</comment>

--- a/Unicord.Universal/Resources/fr/Dialogs.resw
+++ b/Unicord.Universal/Resources/fr/Dialogs.resw
@@ -157,7 +157,7 @@
     <value>Oui</value>
   </data>
   <data name="ConfirmationDialog.SecondaryButtonText" xml:space="preserve">
-    <value>Non</value>
+    <value>Annuler</value>
   </data>
   <data name="DeleteMessageDialog.PrimaryButtonText" xml:space="preserve">
     <value>Super !</value>

--- a/Unicord.Universal/Resources/fr/SecuritySettingsPage.resw
+++ b/Unicord.Universal/Resources/fr/SecuritySettingsPage.resw
@@ -148,6 +148,9 @@
     <value></value>
   </data>
   <data name="WindowsHelloUnavailable.Text" xml:space="preserve">
-    <value>Windows Hello n'est pas disponible sur cet appareil. Voulez-vous [changer cela?] (ms-settings:signinoptions)</value>
+    <value>Windows Hello n'est pas disponible sur cet appareil. Voulez-vous changer cela?</value>
+  </data>
+  <data name="OpenSettingsButton.Content" xml:space="preserve">
+    <value>Ouvrir les paramétres</value>
   </data>
 </root>

--- a/Unicord.Universal/Resources/fr/SettingsPage.resw
+++ b/Unicord.Universal/Resources/fr/SettingsPage.resw
@@ -138,4 +138,10 @@
   <data name="VoiceItem.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Voix</value>
   </data>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Rechercher</value>
+  </data>
+  <data name="EditProfileText.Text" xml:space="preserve">
+    <value>Modifier les profils</value>
+  </data>
 </root>

--- a/Unicord.Universal/Resources/ja-JP/AccountsSettingsPage.resw
+++ b/Unicord.Universal/Resources/ja-JP/AccountsSettingsPage.resw
@@ -120,8 +120,11 @@
   <data name="AccountsSettingsPage.Tag" xml:space="preserve">
     <value>アカウント</value>
   </data>
-  <data name="BackgroundNotificationsBlock.Description" xml:space="preserve">
+  <data name="BackgroundNotificationsDescriptionWin10" xml:space="preserve">
     <value>通知の表示とライブタイル更新のためにUnicordへバックグラウンド処理の許可を与える。</value>
+  </data>
+  <data name="BackgroundNotificationsDescriptionWin11" xml:space="preserve">
+    <value>通知の表示のためにUnicordへバックグラウンド処理の許可を与える。</value>
   </data>
   <data name="BackgroundNotificationsBlock.Title" xml:space="preserve">
     <value>バックグラウンド通知</value>
@@ -144,6 +147,9 @@
   <data name="LogoutBlock.Title" xml:space="preserve">
     <value>ログアウト</value>
   </data>
+  <data name="LogoutButton.Content" xml:space="preserve">
+    <value>ログアウト</value>
+  </data>
   <data name="LogoutPromptMessage" xml:space="preserve">
     <value>本当にログアウトしますか？</value>
   </data>
@@ -152,6 +158,18 @@
   </data>
   <data name="StatisticsText.Text" xml:space="preserve">
     <value>統計</value>
+  </data>
+  <data name="StatisticsBlock.Title" xml:space="preserve">
+    <value>統計</value>
+  </data>
+  <data name="StatisticsBlock.Description" xml:space="preserve">
+    <value>アカウントに関する詳細な統計情報を表示します</value>
+  </data>
+  <data name="CopyStatisticsButton.Content" xml:space="preserve">
+    <value>コピー</value>
+  </data>
+  <data name="CopyStatisticsButtonText.Text" xml:space="preserve">
+    <value>コピー</value>
   </data>
   <data name="SyncContactsBlock.Description" xml:space="preserve">
     <value>DiscordとPeopleアプリの連絡先を同期します。</value>

--- a/Unicord.Universal/Resources/ja-JP/Dialogs.resw
+++ b/Unicord.Universal/Resources/ja-JP/Dialogs.resw
@@ -157,7 +157,7 @@
     <value>はい</value>
   </data>
   <data name="ConfirmationDialog.SecondaryButtonText" xml:space="preserve">
-    <value>いいえ</value>
+    <value>キャンセル</value>
   </data>
   <data name="DeleteMessageDialog.PrimaryButtonText" xml:space="preserve">
     <value>はい</value>

--- a/Unicord.Universal/Resources/ja-JP/NotificationsSettingsPage.resw
+++ b/Unicord.Universal/Resources/ja-JP/NotificationsSettingsPage.resw
@@ -133,7 +133,7 @@
     <value>未読のDM数をバッジで表示する</value>
   </data>
   <data name="EnableDesktopNotifications.Description" xml:space="preserve">
-    <value>メンションやDMが来た際に、デスクトップ上とアクションセンター内に通知を表示します。</value>
+    <value>メンションやDMが来た際に、デスクトップ上と通知センター内に通知を表示します。</value>
   </data>
   <data name="EnableDesktopNotifications.Title" xml:space="preserve">
     <value>デスクトップ通知を有効にする</value>
@@ -144,10 +144,19 @@
   <data name="EnableLiveTiles.Title" xml:space="preserve">
     <value>ライブタイルを有効にする</value>
   </data>
-  <data name="EnableNotifications.Description" xml:space="preserve">
+  <data name="EnableNotificationsDescriptionWin10" xml:space="preserve">
     <value>スタート画面やアクションセンター、タスクバーにメッセージに関する通知を表示します。</value>
+  </data>
+  <data name="EnableNotificationsDescriptionWin11" xml:space="preserve">
+    <value>通知センターやタスクバーにメッセージに関する通知を表示します。</value>
   </data>
   <data name="EnableNotifications.Title" xml:space="preserve">
     <value>通知を有効にする</value>
+  </data>
+  <data name="EnableDesktopNotificationsDescriptionWin10" xml:space="preserve">
+    <value>メンションやDMが来た際に、デスクトップ上とアクションセンター内に通知を表示します。</value>
+  </data>
+  <data name="EnableDesktopNotificationsDescriptionWin11" xml:space="preserve">
+    <value>メンションやDMが来た際に、デスクトップ上と通知センター内に通知を表示します。</value>
   </data>
 </root>

--- a/Unicord.Universal/Resources/ja-JP/SecuritySettingsPage.resw
+++ b/Unicord.Universal/Resources/ja-JP/SecuritySettingsPage.resw
@@ -151,6 +151,9 @@
     <value />
   </data>
   <data name="WindowsHelloUnavailable.Text" xml:space="preserve">
-    <value>Windows Helloはこのデバイスでは利用できません。[有効にする](ms-settings:signinoptions)</value>
+    <value>このデバイスでは Windows Hello が利用できません。有効にしますか?</value>
+  </data>
+  <data name="OpenSettingsButton.Content" xml:space="preserve">
+    <value>設定を開く</value>
   </data>
 </root>

--- a/Unicord.Universal/Resources/ja-JP/SettingsPage.resw
+++ b/Unicord.Universal/Resources/ja-JP/SettingsPage.resw
@@ -140,5 +140,9 @@
   </data>
   <data name="VoiceItem.Content" xml:space="preserve">
     <value>通話</value>
+  </data>  <data name="SearchBox.PlaceholderText" xml:space="preserve">
+    <value>検索</value>
   </data>
-</root>
+  <data name="EditProfileText.Text" xml:space="preserve">
+    <value>プロフィール編集</value>
+  </data></root>

--- a/Unicord.Universal/Resources/ru-RU/AccountsSettingsPage.resw
+++ b/Unicord.Universal/Resources/ru-RU/AccountsSettingsPage.resw
@@ -120,8 +120,11 @@
   <data name="AccountsSettingsPage.Tag" xml:space="preserve">
     <value>Аккаунты</value>
   </data>
-  <data name="BackgroundNotificationsBlock.Description" xml:space="preserve">
+  <data name="BackgroundNotificationsDescriptionWin10" xml:space="preserve">
     <value>Разрешить Unicord работать в фоновом режиме для отображения уведомлений и обновления живых плиток.</value>
+  </data>
+  <data name="BackgroundNotificationsDescriptionWin11" xml:space="preserve">
+    <value>Разрешить Unicord работать в фоновом режиме для отображения уведомлений.</value>
   </data>
   <data name="BackgroundNotificationsBlock.Title" xml:space="preserve">
     <value>Фоновые уведомления</value>
@@ -144,6 +147,9 @@
   <data name="LogoutBlock.Title" xml:space="preserve">
     <value>Выйти</value>
   </data>
+  <data name="LogoutButton.Content" xml:space="preserve">
+    <value>Выйти</value>
+  </data>
   <data name="LogoutPromptMessage" xml:space="preserve">
     <value>Вы уверены, что хотите выйти?</value>
   </data>
@@ -152,6 +158,18 @@
   </data>
   <data name="StatisticsText.Text" xml:space="preserve">
     <value>Статистика</value>
+  </data>
+  <data name="StatisticsBlock.Title" xml:space="preserve">
+    <value>Статистика</value>
+  </data>
+  <data name="StatisticsBlock.Description" xml:space="preserve">
+    <value>Просмотр подробной статистики вашего аккаунта</value>
+  </data>
+  <data name="CopyStatisticsButton.Content" xml:space="preserve">
+    <value>Копировать</value>
+  </data>
+  <data name="CopyStatisticsButtonText.Text" xml:space="preserve">
+    <value>Копировать</value>
   </data>
   <data name="SyncContactsBlock.Description" xml:space="preserve">
     <value>Синхронизируйте своих друзей в Discord с приложением Люди.</value>

--- a/Unicord.Universal/Resources/ru-RU/Dialogs.resw
+++ b/Unicord.Universal/Resources/ru-RU/Dialogs.resw
@@ -157,7 +157,7 @@
     <value>Да</value>
   </data>
   <data name="ConfirmationDialog.SecondaryButtonText" xml:space="preserve">
-    <value>Нет</value>
+    <value>Отмена</value>
   </data>
   <data name="DeleteMessageDialog.PrimaryButtonText" xml:space="preserve">
     <value>Да!</value>

--- a/Unicord.Universal/Resources/ru-RU/SecuritySettingsPage.resw
+++ b/Unicord.Universal/Resources/ru-RU/SecuritySettingsPage.resw
@@ -151,6 +151,9 @@
     <value />
   </data>
   <data name="WindowsHelloUnavailable.Text" xml:space="preserve">
-    <value>Windows Hello недоступен на этом устройстве. Хотите [изменить это?](ms-settings:signinoptions)</value>
+    <value>Windows Hello не доступна на этом устройстве. Хотите это исправить?</value>
+  </data>
+  <data name="OpenSettingsButton.Content" xml:space="preserve">
+    <value>Открыть параметры</value>
   </data>
 </root>

--- a/Unicord.Universal/Resources/ru-RU/SettingsPage.resw
+++ b/Unicord.Universal/Resources/ru-RU/SettingsPage.resw
@@ -138,4 +138,10 @@
   <data name="VoiceItem.Content" xml:space="preserve">
     <value>Голосовые звонки</value>
   </data>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Поиск</value>
+  </data>
+  <data name="EditProfileText.Text" xml:space="preserve">
+    <value>Редактировать профили</value>
+  </data>
 </root>

--- a/Unicord.Universal/Themes/Styles/Fluent.xaml
+++ b/Unicord.Universal/Themes/Styles/Fluent.xaml
@@ -27,6 +27,9 @@
                     <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
                     <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
 
+                    <CornerRadius x:Key="AccountsSettings_ProfileCard_CornerRadius">0</CornerRadius>
+                    <CornerRadius x:Key="AccountsSettings_ProfileCard_BannerCornerRadius">0</CornerRadius>
+
                     <!-- General -->
 
                     <SolidColorBrush x:Key="General_Page_BackgroundBrush" Color="{ThemeResource BackgroundPrimaryColour}"/>

--- a/Unicord.Universal/Themes/Styles/Performance.xaml
+++ b/Unicord.Universal/Themes/Styles/Performance.xaml
@@ -32,6 +32,9 @@
                     <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
                     <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
 
+                    <CornerRadius x:Key="AccountsSettings_ProfileCard_CornerRadius">0</CornerRadius>
+                    <CornerRadius x:Key="AccountsSettings_ProfileCard_BannerCornerRadius">0</CornerRadius>
+
                     <SolidColorBrush x:Key="General_Page_BackgroundBrush" Color="{ThemeResource BackgroundPrimaryColour}"/>
 
                     <!-- General -->

--- a/Unicord.Universal/Themes/Styles/SunValley.xaml
+++ b/Unicord.Universal/Themes/Styles/SunValley.xaml
@@ -19,6 +19,9 @@
                     <FontFamily x:Key="PivotHeaderItemFontFamily">Segoe UI Variable</FontFamily>
                     <FontWeight x:Key="PivotHeaderItemThemeFontWeight">Semibold</FontWeight>
 
+                    <CornerRadius x:Key="AccountsSettings_ProfileCard_CornerRadius">8</CornerRadius>
+                    <CornerRadius x:Key="AccountsSettings_ProfileCard_BannerCornerRadius">8,8,0,0</CornerRadius>
+
                     <Style x:Key="CleanButtonStyle" TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
                         <Setter Property="Background" Value="Transparent"/>
                     </Style>


### PR DESCRIPTION
This PR modernizes the Settings UI with Win11-style polish and Discord-inspired profile layout. Features:

- Profile row in Settings navigation with avatar, display name, and search functionality
- Discord-style Accounts summary (vertical banner + overlapping avatar with live presence indicator)
- Display Name / Username ordering (no discriminator tags)
- About page: WinUI-style expander settings card with selectable version
- Notifications/Account summary/Security/Themes: Bundled expanders expander settings card, InfoBar warnings, instant restart dialog
- The OS-aware for specific things between versions. Windows 10 continues to show the Action Center icon along with Live Tiles and People, while Windows 11 uses a Ringer icon, no longer includes Live Tiles and people.
- Show an instant restart dialog when switching a theme and change the "No" button to "Cancel" so that when we click "Cancel," it reselects the previously selected theme.
- Fix the overlapping scrollbar issue on the settings page.
- Move the “Learn More” contrast hyperlink from inside the expander to the descriptions in the settings expander card.

Tested on: Windows 11 Version 25H2 (OS Build 26220.7523) x64

Preview:
- Profile row in Settings navigation with avatar, display name, and search functionality
- Discord-style Accounts summary (vertical banner + overlapping avatar with live presence indicator)
- Display Name / Username ordering (no discriminator tags)
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/ea2b3ea8-e721-4d36-bfbc-c6ac929402e5" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/d27ea1a3-802c-4875-9968-c19f252132d7" />

- About page: WinUI-style expander settings card with selectable version
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/b654f451-c8dd-4d37-849b-84c31fa40e97" />

- Notifications/Account summary/Security/Themes: Bundled expanders expander settings card, InfoBar warnings, border separator
<img width="1513" height="575" alt="image" src="https://github.com/user-attachments/assets/53b0695e-538b-4195-9608-ef723b00ea2d" />
<img width="1519" height="516" alt="image" src="https://github.com/user-attachments/assets/c82f267e-8b0d-488b-b902-9cda5bb4cf15" />
<img width="1522" height="678" alt="image" src="https://github.com/user-attachments/assets/a34e6357-2789-487c-928a-c489de4e445c" />
<img width="1487" height="634" alt="image" src="https://github.com/user-attachments/assets/db98089e-8885-4990-a94b-0e2cedf442e5" />

- Instant restart dialog when we are switching a theme
<img width="1919" height="1016" alt="Screenshot 2025-12-27 025406" src="https://github.com/user-attachments/assets/9e905bd2-2529-4ea5-b5d0-d91342a3dbc2" />

- Move the “Learn More” contrast hyperlink from inside the expander to the descriptions in the settings expander card.
<img width="1493" height="251" alt="Screenshot 2025-12-27 025747" src="https://github.com/user-attachments/assets/edc22a73-5320-452e-a5b1-bdc921f26856" />
