### PR TITLE
Improve User Flyout and Profile Overview

### DIFF
--- a/Unicord.Universal/Controls/EmotePicker.xaml.cs
+++ b/Unicord.Universal/Controls/EmotePicker.xaml.cs
@@ -35,7 +35,12 @@ namespace Unicord.Universal.Controls
         {
             try
             {
-                Source.Source = EmojiUtilities.GetEmoji(new ChannelViewModel(Channel.Id, true), searchBox.Text);
+                ChannelViewModel channelVm = null;
+                if (Channel != null)
+                {
+                    channelVm = new ChannelViewModel(Channel.Id, true);
+                }
+                Source.Source = EmojiUtilities.GetEmoji(channelVm, searchBox.Text);
             }
             catch { }
         }

--- a/Unicord.Universal/Controls/Flyouts/ChannelContextFlyout.xaml
+++ b/Unicord.Universal/Controls/Flyouts/ChannelContextFlyout.xaml
@@ -15,6 +15,13 @@
 
     <MenuFlyoutSeparator/>
 
+    <MenuFlyoutItem x:Name="ProfileItem"
+                    x:Uid="/Flyouts/Profile"
+                    Text="Profile"
+                    Icon="OtherUser"
+                    Visibility="{Binding Recipient, Converter={StaticResource HideOnNullConverter}}"
+                    Click="ProfileItem_Click" />
+
     <MenuFlyoutItem x:Uid="/Flyouts/MarkAsRead" Command="{Binding AcknowledgeCommand}">
         <MenuFlyoutItem.Icon>
             <FontIcon Glyph="&#xE930;" FontFamily="{StaticResource SymbolThemeFontFamily}"/>

--- a/Unicord.Universal/Controls/Flyouts/ChannelContextFlyout.xaml.cs
+++ b/Unicord.Universal/Controls/Flyouts/ChannelContextFlyout.xaml.cs
@@ -1,4 +1,8 @@
-﻿using Windows.UI.Xaml.Controls;
+﻿using Unicord.Universal.Models.Channels;
+using Unicord.Universal.Pages.Overlay;
+using Unicord.Universal.Services;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 
 namespace Unicord.Universal.Controls.Flyouts
 {
@@ -7,6 +11,15 @@ namespace Unicord.Universal.Controls.Flyouts
         public ChannelContextFlyout()
         {
             InitializeComponent();
+        }
+
+        private async void ProfileItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement element && element.DataContext is ChannelViewModel channel && channel.Recipient != null)
+            {
+                await OverlayService.GetForCurrentView()
+                    .ShowOverlayAsync<UserInfoOverlayPage>(channel.Recipient);
+            }
         }
     }
 }

--- a/Unicord.Universal/Controls/Flyouts/DirectMessageContextFlyout.xaml
+++ b/Unicord.Universal/Controls/Flyouts/DirectMessageContextFlyout.xaml
@@ -15,6 +15,11 @@
 
     <MenuFlyoutSeparator/>
 
+    <MenuFlyoutItem x:Name="ProfileItem"
+                   x:Uid="/Flyouts/Profile"
+                   Text="Profile"
+                   Icon="OtherUser"
+                   Click="ProfileItem_Click" />
     <MenuFlyoutItem x:Uid="/Flyouts/MarkAsRead" Command="{Binding AcknowledgeCommand}">
         <MenuFlyoutItem.Icon>
             <FontIcon Glyph="&#xE930;" FontFamily="{StaticResource SymbolThemeFontFamily}"/>

--- a/Unicord.Universal/Controls/Flyouts/DirectMessageContextFlyout.xaml.cs
+++ b/Unicord.Universal/Controls/Flyouts/DirectMessageContextFlyout.xaml.cs
@@ -1,4 +1,8 @@
-﻿using Windows.UI.Xaml.Controls;
+﻿using Unicord.Universal.Models.Channels;
+using Unicord.Universal.Pages.Overlay;
+using Unicord.Universal.Services;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 
 namespace Unicord.Universal.Controls.Flyouts
 {
@@ -7,6 +11,15 @@ namespace Unicord.Universal.Controls.Flyouts
         public DirectMessageContextFlyout()
         {
             InitializeComponent();
+        }
+
+        private async void ProfileItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement element && element.DataContext is ChannelViewModel channel && channel.Recipient != null)
+            {
+                await OverlayService.GetForCurrentView()
+                    .ShowOverlayAsync<UserInfoOverlayPage>(channel.Recipient);
+            }
         }
     }
 }

--- a/Unicord.Universal/Controls/Flyouts/UserFlyout.xaml
+++ b/Unicord.Universal/Controls/Flyouts/UserFlyout.xaml
@@ -11,60 +11,288 @@
     xmlns:user="using:Unicord.Universal.Controls.Users"
     mc:Ignorable="d">
 
-    <Grid x:Name="Root" Width="256" Margin="-12">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
+    <utilities:AdaptiveFlyout.Resources>
+        <Flyout x:Name="EmoteFlyout" x:Key="EmoteFlyout" Opening="EmoteFlyout_Opening" Closed="EmoteFlyout_Closed">
+            <controls:EmotePicker x:Name="EmotePicker"
+                                  Width="300"
+                                  Height="300"
+                                  HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Stretch"
+                                  EmojiPicked="EmotePicker_EmojiPicked" />
+        </Flyout>
+    </utilities:AdaptiveFlyout.Resources>
 
-        <Grid RequestedTheme="Dark" Background="{ThemeResource SystemControlAccentDark1AcrylicElementAccentDark1Brush}">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
+    <Grid x:Name="Root" Width="300" Margin="-12">
+        <Border Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                CornerRadius="{ThemeResource AccountsSettings_ProfileCard_CornerRadius}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="100"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
 
-            <user:AvatarControl Style="{ThemeResource HugeAvatarWithPresenceStyle}"
-                                Width="128"
-                                Height="128"
-                                Margin="24,24,24,8"
-                                Source="{Binding AvatarUrl}"
-                                Presence="{Binding Presence}"/>
-            <StackPanel Grid.Row="1" RequestedTheme="Dark" >
-                <controls:UsernameControl User="{Binding}" FontSize="24" IconSize="24" HorizontalAlignment="Center" Margin="12,0" />
-                <TextBlock Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" TextAlignment="Center" FontSize="16" Margin="0,0,0,24">
-                    @<Run Foreground="{ThemeResource ApplicationForegroundThemeBrush}" Text="{Binding Username}"/>#<Run Text="{Binding Discriminator}"/>
-                </TextBlock>
-            </StackPanel>
-        </Grid>
-        
-        <!--<Grid Grid.Row="1" RequestedTheme="Dark" Visibility="{Binding Presence.Activity.Name, Converter={StaticResource HideOnNullConverter}, FallbackValue=Collapsed}" Background="{ThemeResource SystemControlAccentAcrylicElementAccentMediumHighBrush}" >
-            <controls:RichPresenceControl DataContext="{Binding Presence.Activity}" Margin="8" />
-        </Grid>-->
-        
-        <Grid Grid.Row="2" Background="{ThemeResource SystemControlAcrylicElementMediumHighBrush}">
-            <StackPanel Margin="12,8,12,12" Visibility="{Binding Roles, Converter={StaticResource BoolVisibilityConverter}, FallbackValue=Collapsed}">
-                <TextBlock x:Uid="/Dialogs/ProfileRoles" Style="{ThemeResource BaseTextBlockStyle}" Margin="0,0,0,8"/>
-                <ItemsControl ItemTemplate="{ThemeResource RoleTemplate}" ItemsSource="{Binding Roles}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <controls1:WrapPanel VerticalSpacing="4" HorizontalSpacing="4"/>
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                </ItemsControl>
-            </StackPanel>
-        </Grid>
+                <!-- Banner -->
+                <Border Grid.Row="0"
+                        Background="{ThemeResource LayerFillColorAltBrush}"
+                        CornerRadius="{ThemeResource AccountsSettings_ProfileCard_BannerCornerRadius}" />
 
-        <StackPanel HorizontalAlignment="Stretch" Grid.Row="3" Background="{ThemeResource SystemControlAcrylicElementMediumHighBrush}">
-            <controls:IconLabelButton Icon="&#xE7EE;" Tapped="IconLabelButton_Tapped" Command="{Binding OpenOverlayCommand}">
-                <TextBlock TextTrimming="CharacterEllipsis" x:Uid="/Flyouts/ShowFullProfile"/>
-            </controls:IconLabelButton>
-            <controls:IconLabelButton Icon="&#xE724;" Command="{Binding SendMessageCommand}">
-                <TextBlock TextTrimming="CharacterEllipsis" x:Uid="/Flyouts/SendMessage"/>
-            </controls:IconLabelButton>
-        </StackPanel>
-       
+                <Button Grid.Row="0"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
+                        Margin="0,8,8,0"
+                        Padding="4"
+                        Background="Transparent"
+                        BorderBrush="Transparent"
+                        ToolTipService.ToolTip="More">
+                    <Button.Content>
+                        <FontIcon Glyph="&#xE10C;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                    </Button.Content>
+                    <Button.Flyout>
+                        <MenuFlyout>
+                            <MenuFlyoutItem Text="View Full Profile" Click="ViewFullProfile_Click" Command="{Binding OpenOverlayCommand}">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xE7EE;" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                            <MenuFlyoutItem Text="Copy User ID" Click="CopyUserId_Click">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xEC7A;" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                        </MenuFlyout>
+                    </Button.Flyout>
+                </Button>
+
+                <!-- Header + actions -->
+                <Grid Grid.Row="1" Margin="16,0,16,12">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <!-- Avatar overlapping banner -->
+                    <Grid Width="72" Height="72" Margin="0,-36,0,0" HorizontalAlignment="Left">
+                        <Border CornerRadius="36"
+                                BorderBrush="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                                BorderThickness="6"
+                                Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}" />
+
+                        <user:AvatarControl Margin="6"
+                                           Style="{ThemeResource LargeAvatarWithPresenceStyle}"
+                                           Source="{Binding AvatarUrl}"
+                                           Presence="{Binding Presence}" />
+                    </Grid>
+
+                    <!-- Names -->
+                    <StackPanel Grid.Row="1" Margin="0,10,0,0">
+                        <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                                   Text="{Binding DisplayName}"
+                                       TextTrimming="Clip"
+                                   IsTextSelectionEnabled="True"
+                                       TextWrapping="Wrap"
+                                       MaxLines="2" />
+                        <TextBlock Style="{ThemeResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   Text="{Binding Username}"
+                                   TextTrimming="CharacterEllipsis"
+                                   IsTextSelectionEnabled="True"
+                                   TextWrapping="NoWrap" />
+                    </StackPanel>
+
+                    <!-- Mutual Friends / Servers (wraps like role pills when too wide) -->
+                    <controls1:WrapPanel Grid.Row="2"
+                                         Orientation="Horizontal"
+                                         Margin="0,8,0,12"
+                                         VerticalSpacing="2"
+                                         Visibility="{Binding HasMutualInfo, Converter={StaticResource BoolVisibilityConverter}}">
+
+                        <!-- Friends group (icons + link + dot) -->
+                        <StackPanel x:Name="MutualFriendsGroup" Orientation="Horizontal" Margin="0,0,12,0" Visibility="Collapsed">
+                            <!-- Friend Icons (up to 3, shown when mutual friends exist) -->
+                            <StackPanel x:Name="MutualFriendIcons" Orientation="Horizontal" Spacing="-6" Visibility="Collapsed" Margin="0,0,12,0">
+                                <lib:PersonPicture x:Name="FriendIcon1"
+                                                  Width="20"
+                                                  Height="20"
+                                                  Visibility="Collapsed" />
+                                <lib:PersonPicture x:Name="FriendIcon2"
+                                                  Width="20"
+                                                  Height="20"
+                                                  Visibility="Collapsed" />
+                                <lib:PersonPicture x:Name="FriendIcon3"
+                                                  Width="20"
+                                                  Height="20"
+                                                  Visibility="Collapsed" />
+                            </StackPanel>
+
+                            <!-- Mutual Friends (priority display when > 0) -->
+                            <HyperlinkButton x:Name="MutualFriendsButton"
+                                             Padding="0"
+                                             Margin="0,0,8,0"
+                                             VerticalAlignment="Center"
+                                             Visibility="Collapsed"
+                                             Click="MutualFriends_Click">
+                                <TextBlock Style="{ThemeResource CaptionTextBlockStyle}">
+                                    <Run Text="{Binding MutualFriendsCount}"/>
+                                    <Run Text="Mutual Friends"/>
+                                </TextBlock>
+                            </HyperlinkButton>
+
+                            <!-- Separator dot -->
+                            <Ellipse x:Name="MutualSeparator"
+                                     Width="5"
+                                     Height="5"
+                                     Margin="3,0,0,0"
+                                     Fill="{ThemeResource TextFillColorTertiaryBrush}"
+                                     VerticalAlignment="Center"
+                                     Visibility="Collapsed" />
+                        </StackPanel>
+
+                        <!-- Servers group (icons + link) -->
+                        <StackPanel x:Name="MutualServersGroup" Orientation="Horizontal" Visibility="Collapsed">
+                            <!-- Server Icons (up to 3, hidden if mutual friends exist) -->
+                            <StackPanel x:Name="MutualServerIcons"
+                                        Orientation="Horizontal"
+                                        Spacing="-6"
+                                        Visibility="Collapsed"
+                                        Margin="0,0,6,0">
+                                <lib:PersonPicture x:Name="ServerIcon1"
+                                                  Width="20"
+                                                  Height="20"
+                                                  Visibility="Collapsed" />
+                                <lib:PersonPicture x:Name="ServerIcon2"
+                                                  Width="20"
+                                                  Height="20"
+                                                  Visibility="Collapsed" />
+                                <lib:PersonPicture x:Name="ServerIcon3"
+                                                  Width="20"
+                                                  Height="20"
+                                                  Visibility="Collapsed" />
+                            </StackPanel>
+
+                            <!-- Mutual Servers Text -->
+                            <HyperlinkButton x:Name="MutualServersButton"
+                                             Padding="0"
+                                             VerticalAlignment="Center"
+                                             Click="MutualServers_Click">
+                                <TextBlock Style="{ThemeResource CaptionTextBlockStyle}">
+                                    <Run Text="{Binding MutualGuilds.Count}"/>
+                                    <Run Text="Mutual Servers"/>
+                                </TextBlock>
+                            </HyperlinkButton>
+                        </StackPanel>
+                    </controls1:WrapPanel>
+                </Grid>
+
+                <!-- Roles (if guild member) -->
+                <StackPanel x:Name="RolesSection"
+                            Grid.Row="2"
+                            Margin="16,0,16,12"
+                            Visibility="{Binding Roles, Converter={StaticResource BoolVisibilityConverter}, FallbackValue=Collapsed}">
+                    <Grid Margin="0,0,0,8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Uid="/Dialogs/ProfileRoles"
+                                   Style="{ThemeResource BodyStrongTextBlockStyle}" />
+                        <Button x:Name="RolesExpandButton"
+                                Grid.Column="1"
+                                Margin="0"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Top"
+                                Padding="0"
+                                Background="Transparent"
+                                BorderBrush="Transparent"
+                                Visibility="Collapsed"
+                                Click="RolesExpandButton_Click">
+                            <ToolTipService.ToolTip>
+                                <TextBlock x:Name="RolesExpandTooltip" Text="Show All Roles"/>
+                            </ToolTipService.ToolTip>
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <TextBlock x:Name="RolesMoreCount"
+                                           Style="{ThemeResource CaptionTextBlockStyle}"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                <FontIcon x:Name="RolesExpandIcon"
+                                          Glyph="&#xE70D;"
+                                          FontSize="12"
+                                          FontFamily="{StaticResource SymbolThemeFontFamily}"/>
+                            </StackPanel>
+                        </Button>
+                    </Grid>
+                    <ItemsControl x:Name="RolesItemsControl"
+                                  ItemTemplate="{ThemeResource RoleTemplate}"
+                                  ItemsSource="{Binding Roles}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <controls1:WrapPanel x:Name="RolesWrapPanel" VerticalSpacing="4" HorizontalSpacing="4"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Message Textbox -->
+                <Grid Grid.Row="3" Margin="0,0,0,0">
+                    <!-- Composer (other users) -->
+                    <Border Margin="12,12,12,12"
+                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            BorderBrush="{ThemeResource ChannelPage_MessageInput_BorderBrush}"
+                            BorderThickness="{ThemeResource ChannelPage_MessageInput_BorderThickness}"
+                            CornerRadius="{ThemeResource ChannelPage_MessageInput_CornerRadius}"
+                            Visibility="{Binding IsCurrent, Converter={StaticResource InverseBoolVisibilityConverter}, FallbackValue=Visible}">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            
+                            <ScrollViewer Grid.Column="0"
+                                          MaxHeight="200"
+                                          VerticalScrollBarVisibility="Auto"
+                                          HorizontalScrollBarVisibility="Disabled">
+                                <TextBox x:Name="MessageTextBox"
+                                         Style="{ThemeResource MessageTextBoxStyle}"
+                                         MaxLength="2000"
+                                         AcceptsReturn="False"
+                                         TextWrapping="Wrap"
+                                         Loaded="MessageTextBox_Loaded"
+                                         KeyDown="MessageTextBox_KeyDown" />
+                            </ScrollViewer>
+                            
+                            <ToggleButton x:Name="EmoteButton"
+                                          Grid.Column="1"
+                                          Content="&#xED54;"
+                                          Margin="4,4,0,4"
+                                          VerticalAlignment="Bottom"
+                                          Style="{ThemeResource IconToggleButtonStyle}"
+                                          Click="EmoteButton_Click" />
+
+                            <Button x:Name="SendButton"
+                                Grid.Column="2"
+                                Content="&#xE724;"
+                                Margin="4"
+                                VerticalAlignment="Bottom"
+                                Style="{ThemeResource IconButtonStyle}"
+                                Click="SendButton_Click" />
+                        </Grid>
+                    </Border>
+
+                    <!-- Edit Profile (current user) -->
+                    <Grid Margin="12,12,12,12"
+                          Visibility="{Binding IsCurrent, Converter={StaticResource BoolVisibilityConverter}, FallbackValue=Collapsed}">
+                        <Button Content="Edit Profile"
+                                HorizontalAlignment="Stretch"
+                                Style="{ThemeResource AccentButtonStyle}"
+                                Click="EditProfile_Click" />
+                    </Grid>
+                </Grid>
+            </Grid>
+        </Border>
     </Grid>
 </utilities:AdaptiveFlyout>

--- a/Unicord.Universal/Controls/Flyouts/UserFlyout.xaml
+++ b/Unicord.Universal/Controls/Flyouts/UserFlyout.xaml
@@ -275,6 +275,7 @@
                                           Content="&#xED54;"
                                           Margin="4,4,0,4"
                                           VerticalAlignment="Bottom"
+                                          VerticalAlignment="Center"
                                           Style="{ThemeResource IconToggleButtonStyle}"
                                           Click="EmoteButton_Click" />
 
@@ -282,7 +283,7 @@
                                 Grid.Column="2"
                                 Content="&#xE724;"
                                 Margin="4"
-                                VerticalAlignment="Bottom"
+                                VerticalAlignment="Center"
                                 Style="{ThemeResource IconButtonStyle}"
                                 Click="SendButton_Click" />
                         </Grid>

--- a/Unicord.Universal/Controls/Flyouts/UserFlyout.xaml
+++ b/Unicord.Universal/Controls/Flyouts/UserFlyout.xaml
@@ -221,7 +221,12 @@
                                 <FontIcon x:Name="RolesExpandIcon"
                                           Glyph="&#xE70D;"
                                           FontSize="12"
-                                          FontFamily="{StaticResource SymbolThemeFontFamily}"/>
+                                          RenderTransformOrigin="0.5,0.5"
+                                          FontFamily="{StaticResource SymbolThemeFontFamily}">
+                                    <FontIcon.RenderTransform>
+                                        <RotateTransform x:Name="RolesExpandIconRotation" Angle="0"/>
+                                    </FontIcon.RenderTransform>
+                                </FontIcon>
                             </StackPanel>
                         </Button>
                     </Grid>

--- a/Unicord.Universal/Controls/Flyouts/UserFlyout.xaml.cs
+++ b/Unicord.Universal/Controls/Flyouts/UserFlyout.xaml.cs
@@ -1,19 +1,419 @@
-﻿using Unicord.Universal.Utilities;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using DSharpPlus;
+using DSharpPlus.Entities;
+using Unicord.Universal.Services;
+using Unicord.Universal.Utilities;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.UI.Core;
+using Windows.System;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
 
 namespace Unicord.Universal.Controls.Flyouts
 {
     public sealed partial class UserFlyout : AdaptiveFlyout
     {
+        private static Thickness MutualIconsMarginForCount(int count)
+        {
+            var right = count switch
+            {
+                1 => 18,
+                2 => 12,
+                3 => 6,
+                _ => 12,
+            };
+
+            return new Thickness(0, 0, right, 0);
+        }
+
+        private bool _rolesExpanded = false;
+
         public UserFlyout(object param) : base(param)
         {
             InitializeComponent();
+            DataContextChanged += UserFlyout_DataContextChanged;
+            Loaded += UserFlyout_Loaded;
         }
 
-        // i dislike this
-        private void IconLabelButton_Tapped(object sender, TappedRoutedEventArgs e)
+        private void UserFlyout_Loaded(object sender, RoutedEventArgs e)
         {
+            UpdateRolesDisplay();
+        }
 
+        private void UserFlyout_DataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+        {
+            UpdateMutualDisplay();
+            _rolesExpanded = false;
+            UpdateRolesDisplay();
+        }
+
+        private void UpdateRolesDisplay()
+        {
+            if (DataContext is not Unicord.Universal.Models.User.UserViewModel user || user.Roles == null)
+                return;
+
+            var roleCount = user.Roles.Count;
+            
+            // Estimate ~5 roles fit in 2 rows
+            const int visibleRolesInCollapsedMode = 5;
+            
+            if (roleCount <= visibleRolesInCollapsedMode)
+            {
+                // Few roles, show all and hide expander
+                RolesExpandButton.Visibility = Visibility.Collapsed;
+                RolesItemsControl.MaxHeight = double.PositiveInfinity;
+                return;
+            }
+
+            // Many roles, show expander
+            RolesExpandButton.Visibility = Visibility.Visible;
+
+            if (_rolesExpanded)
+            {
+                RolesItemsControl.MaxHeight = double.PositiveInfinity;
+                RolesExpandIcon.Glyph = "\uE70E"; // ChevronUp
+                RolesMoreCount.Text = "Show less";
+                RolesExpandTooltip.Text = "Collapse Roles";
+            }
+            else
+            {
+                RolesItemsControl.MaxHeight = 60; // ~2 rows at approximately 30px per row
+                RolesExpandIcon.Glyph = "\uE70D"; // ChevronDown
+                var hiddenCount = roleCount - visibleRolesInCollapsedMode;
+                RolesMoreCount.Text = $"+{hiddenCount} more";
+                RolesExpandTooltip.Text = "Show All Roles";
+            }
+        }
+
+        private void RolesExpandButton_Click(object sender, RoutedEventArgs e)
+        {
+            _rolesExpanded = !_rolesExpanded;
+            UpdateRolesDisplay();
+        }
+
+        private void UpdateMutualDisplay()
+        {
+            if (DataContext is not Unicord.Universal.Models.User.UserViewModel user)
+                return;
+
+            var mutualFriendsCount = user.MutualFriendsCount;
+            var mutualFriends = user.MutualFriends;
+            var mutualGuilds = user.MutualGuilds;
+            var mutualGuildsCount = mutualGuilds?.Count ?? 0;
+
+            // Reset to a clean baseline so spacing doesn't get stuck when switching users.
+            MutualFriendsButton.Visibility = Visibility.Collapsed;
+            MutualFriendIcons.Visibility = Visibility.Collapsed;
+            MutualServerIcons.Visibility = Visibility.Collapsed;
+            MutualSeparator.Visibility = Visibility.Collapsed;
+            MutualFriendIcons.Margin = MutualIconsMarginForCount(2);
+            MutualServerIcons.Margin = MutualIconsMarginForCount(2);
+            MutualFriendsGroup.Visibility = Visibility.Collapsed;
+            MutualServersGroup.Visibility = Visibility.Collapsed;
+
+            // If mutual friends exist, show them with friend icons and hide server icons
+            if (mutualFriendsCount > 0)
+            {
+                MutualFriendsGroup.Visibility = Visibility.Visible;
+                MutualServersGroup.Visibility = Visibility.Visible;
+                MutualFriendsButton.Visibility = Visibility.Visible;
+                MutualFriendIcons.Visibility = Visibility.Visible;
+                MutualServerIcons.Visibility = Visibility.Collapsed;
+                MutualSeparator.Visibility = mutualGuildsCount > 0 ? Visibility.Visible : Visibility.Collapsed;
+
+                // Populate up to 3 friend icons
+                var friendIconsToShow = System.Math.Min(3, mutualFriendsCount);
+
+                MutualFriendIcons.Margin = MutualIconsMarginForCount(friendIconsToShow);
+                
+                FriendIcon1.Visibility = friendIconsToShow >= 1 ? Visibility.Visible : Visibility.Collapsed;
+                FriendIcon2.Visibility = friendIconsToShow >= 2 ? Visibility.Visible : Visibility.Collapsed;
+                FriendIcon3.Visibility = friendIconsToShow >= 3 ? Visibility.Visible : Visibility.Collapsed;
+
+                if (friendIconsToShow >= 1)
+                {
+                    FriendIcon1.DisplayName = mutualFriends[0].DisplayName;
+                    FriendIcon1.ProfilePicture = CreateImageSource(mutualFriends[0].AvatarUrl);
+                }
+                if (friendIconsToShow >= 2)
+                {
+                    FriendIcon2.DisplayName = mutualFriends[1].DisplayName;
+                    FriendIcon2.ProfilePicture = CreateImageSource(mutualFriends[1].AvatarUrl);
+                }
+                if (friendIconsToShow >= 3)
+                {
+                    FriendIcon3.DisplayName = mutualFriends[2].DisplayName;
+                    FriendIcon3.ProfilePicture = CreateImageSource(mutualFriends[2].AvatarUrl);
+                }
+            }
+            else if (mutualGuildsCount > 0)
+            {
+                MutualServersGroup.Visibility = Visibility.Visible;
+                // No mutual friends, show server icons (up to 3)
+                MutualFriendsButton.Visibility = Visibility.Collapsed;
+                MutualFriendIcons.Visibility = Visibility.Collapsed;
+                MutualServerIcons.Visibility = Visibility.Visible;
+                MutualSeparator.Visibility = Visibility.Collapsed;
+
+                // Populate up to 3 server icons
+                var iconsToShow = System.Math.Min(3, mutualGuildsCount);
+
+                MutualServerIcons.Margin = MutualIconsMarginForCount(iconsToShow);
+                
+                ServerIcon1.Visibility = iconsToShow >= 1 ? Visibility.Visible : Visibility.Collapsed;
+                ServerIcon2.Visibility = iconsToShow >= 2 ? Visibility.Visible : Visibility.Collapsed;
+                ServerIcon3.Visibility = iconsToShow >= 3 ? Visibility.Visible : Visibility.Collapsed;
+
+                if (iconsToShow >= 1)
+                {
+                    ServerIcon1.DisplayName = mutualGuilds[0].Name;
+                    ServerIcon1.ProfilePicture = mutualGuilds[0].Icon;
+                }
+                if (iconsToShow >= 2)
+                {
+                    ServerIcon2.DisplayName = mutualGuilds[1].Name;
+                    ServerIcon2.ProfilePicture = mutualGuilds[1].Icon;
+                }
+                if (iconsToShow >= 3)
+                {
+                    ServerIcon3.DisplayName = mutualGuilds[2].Name;
+                    ServerIcon3.ProfilePicture = mutualGuilds[2].Icon;
+                }
+            }
+        }
+
+        private static ImageSource CreateImageSource(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+                return null;
+
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+                return null;
+
+            return new BitmapImage(uri);
+        }
+
+        private void ViewFullProfile_Click(object sender, RoutedEventArgs e)
+        {
+            // "View Full Profile" runs via the command binding;
+            CloseHostFlyout();
+        }
+
+        private async void MutualFriends_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is Unicord.Universal.Models.User.UserViewModel user)
+            {
+                CloseHostFlyout();
+                await OverlayService.GetForCurrentView()
+                    .ShowOverlayAsync<Pages.Overlay.UserInfoOverlayPage>((user, "mutualfriends"));
+            }
+        }
+
+        private async void MutualServers_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is Unicord.Universal.Models.User.UserViewModel user)
+            {
+                CloseHostFlyout();
+                await OverlayService.GetForCurrentView()
+                    .ShowOverlayAsync<Pages.Overlay.UserInfoOverlayPage>((user, "mutual"));
+            }
+        }
+
+        private void CopyUserId_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is Unicord.Universal.Models.User.UserViewModel user && user.User?.Id != null)
+            {
+                var dataPackage = new DataPackage();
+                dataPackage.SetText(user.User.Id.ToString());
+                Clipboard.SetContent(dataPackage);
+            }
+        }
+
+        private void MessageTextBox_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (sender is Windows.UI.Xaml.Controls.TextBox textBox && DataContext is Unicord.Universal.Models.User.UserViewModel user)
+            {
+                textBox.PlaceholderText = $"Message @{user.Username}";
+            }
+        }
+
+        private async void MessageTextBox_KeyDown(object sender, KeyRoutedEventArgs e)
+        {
+            if (e.Key != VirtualKey.Enter)
+                return;
+
+            e.Handled = true;
+
+            var isShiftDown = Window.Current?.CoreWindow?.GetKeyState(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down) == true;
+            if (isShiftDown)
+            {
+                if (MessageTextBox == null)
+                    return;
+
+                var cursorPosition = MessageTextBox.SelectionStart;
+                var text = MessageTextBox.Text ?? string.Empty;
+                var newline = "\r\n";
+
+                MessageTextBox.Text = text.Insert(cursorPosition, newline);
+                MessageTextBox.SelectionStart = cursorPosition + newline.Length;
+                return;
+            }
+
+            await TrySendMessageAsync();
+
+            // If it sent successfully, close.
+            // (TrySendMessageAsync handles empty text / missing DM channel.)
+            if (string.IsNullOrWhiteSpace(MessageTextBox?.Text))
+                CloseHostFlyout();
+        }
+
+        private async void SendButton_Click(object sender, RoutedEventArgs e)
+        {
+            var sent = await TrySendMessageAsync();
+            if (sent)
+                CloseHostFlyout();
+        }
+
+        private async Task<bool> TrySendMessageAsync()
+        {
+            try
+            {
+                var text = MessageTextBox?.Text;
+                if (string.IsNullOrWhiteSpace(text))
+                    return false;
+
+                if (DataContext is not Unicord.Universal.Models.User.UserViewModel user)
+                    return false;
+
+                DiscordDmChannel dmChannel = null;
+
+                // Prefer the member API when available
+                if (user.Member != null)
+                {
+                    await user.Member.SendMessageAsync(text);
+                    
+                    // Try to get the DM channel that was created
+                    var discord = DiscordManager.Discord;
+                    dmChannel = discord?.PrivateChannels.Values
+                        .FirstOrDefault(c => c.Type == ChannelType.Private && c.Recipients.Count == 1 && c.Recipients[0].Id == user.Id);
+                }
+                else
+                {
+                    // No member context (e.g., DM user). We can only send if a DM channel is already cached.
+                    var discord = DiscordManager.Discord;
+                    if (discord == null)
+                        return false;
+
+                    dmChannel = discord.PrivateChannels.Values
+                        .FirstOrDefault(c => c.Type == ChannelType.Private && c.Recipients.Count == 1 && c.Recipients[0].Id == user.Id);
+
+                    if (dmChannel == null)
+                        return false;
+
+                    await dmChannel.SendMessageAsync(text);
+                }
+
+                MessageTextBox.Text = string.Empty;
+
+                // Navigate to the DM conversation
+                if (dmChannel != null)
+                {
+                    var navigationService = DiscordNavigationService.GetForCurrentView();
+                    await navigationService.NavigateAsync(dmChannel);
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex);
+                return false;
+            }
+        }
+
+        private void EmoteButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (EmoteFlyout != null && EmoteButton != null)
+            {
+                if (EmoteButton.IsChecked == true)
+                {
+                    EmoteFlyout.ShowAt(EmoteButton);
+                }
+                else
+                {
+                    EmoteFlyout.Hide();
+                }
+            }
+        }
+
+        private void EmoteFlyout_Opening(object sender, object e)
+        {
+            if (DataContext is Unicord.Universal.Models.User.UserViewModel user && EmotePicker != null)
+            {
+                // If user has a guild context, use any channel from that guild
+                if (user.Guild != null)
+                {
+                    var channelVm = user.Guild.AccessibleChannels?.FirstOrDefault();
+                    if (channelVm != null)
+                    {
+                        EmotePicker.Channel = channelVm.Channel;
+                    }
+                    else
+                    {
+                        EmotePicker.Channel = null;
+                    }
+                }
+                else
+                {
+                    EmotePicker.Channel = null;
+                }
+
+                // Refresh items now that Channel may have changed
+                EmotePicker.Load();
+            }
+        }
+
+        private void EmoteFlyout_Closed(object sender, object e)
+        {
+            if (EmoteButton != null)
+            {
+                EmoteButton.IsChecked = false;
+            }
+        }
+
+        private void EmotePicker_EmojiPicked(object sender, Models.Emoji.EmojiViewModel e)
+        {
+            if (MessageTextBox != null)
+            {
+                var cursorPosition = MessageTextBox.SelectionStart;
+                var text = MessageTextBox.Text ?? "";
+                
+                // Insert emoji at cursor position
+                MessageTextBox.Text = text.Insert(cursorPosition, e.ToString());
+                
+                // Move cursor after the inserted emoji
+                MessageTextBox.SelectionStart = cursorPosition + e.ToString().Length;
+                
+                // Focus back to the textbox
+                MessageTextBox.Focus(FocusState.Programmatic);
+            }
+            
+            // Close the flyout and uncheck the button
+            EmoteFlyout?.Hide();
+            if (EmoteButton != null)
+            {
+                EmoteButton.IsChecked = false;
+            }
+        }
+
+        private async void EditProfile_Click(object sender, RoutedEventArgs e)
+        {
+            CloseHostFlyout();
+            await SettingsService.GetForCurrentView().OpenAsync(SettingsPageType.Accounts);
         }
     }
 }

--- a/Unicord.Universal/Controls/Flyouts/UserFlyout.xaml.cs
+++ b/Unicord.Universal/Controls/Flyouts/UserFlyout.xaml.cs
@@ -150,7 +150,6 @@ namespace Unicord.Universal.Controls.Flyouts
             const double collapsedMaxHeight = 60; // ~2 rows at approximately 30px per row
 
             // Determine whether content actually overflows the collapsed height.
-            // The previous implementation used a fixed role count estimate, which can be wrong
             // depending on wrap width and role pill sizes.
             var availableWidth = RolesItemsControl.ActualWidth;
             if (availableWidth <= 0)
@@ -177,7 +176,6 @@ namespace Unicord.Universal.Controls.Flyouts
             // Many roles (or narrow layout): show expander
             RolesExpandButton.Visibility = Visibility.Visible;
             
-            // FORCE collapsed state - roles expander ALWAYS starts collapsed
             RolesItemsControl.MaxHeight = collapsedMaxHeight;
             RolesExpandIcon.Glyph = "\uE70D"; // ChevronDown
             var hiddenCount = GetHiddenRolesCount(collapsedMaxHeight, user.Roles.Count);

--- a/Unicord.Universal/Controls/Flyouts/UserFlyout.xaml.cs
+++ b/Unicord.Universal/Controls/Flyouts/UserFlyout.xaml.cs
@@ -7,8 +7,10 @@ using Unicord.Universal.Services;
 using Unicord.Universal.Utilities;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.UI.Core;
+using Windows.Foundation;
 using Windows.System;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
@@ -31,6 +33,7 @@ namespace Unicord.Universal.Controls.Flyouts
         }
 
         private bool _rolesExpanded = false;
+        private bool _rolesAutoExpanded = false;
 
         public UserFlyout(object param) : base(param)
         {
@@ -41,6 +44,7 @@ namespace Unicord.Universal.Controls.Flyouts
 
         private void UserFlyout_Loaded(object sender, RoutedEventArgs e)
         {
+            _rolesAutoExpanded = false;
             UpdateRolesDisplay();
         }
 
@@ -48,51 +52,188 @@ namespace Unicord.Universal.Controls.Flyouts
         {
             UpdateMutualDisplay();
             _rolesExpanded = false;
+            _rolesAutoExpanded = false;
             UpdateRolesDisplay();
+        }
+
+        private static T FindDescendant<T>(DependencyObject root) where T : DependencyObject
+        {
+            if (root == null)
+                return null;
+
+            var count = VisualTreeHelper.GetChildrenCount(root);
+            for (var i = 0; i < count; i++)
+            {
+                var child = VisualTreeHelper.GetChild(root, i);
+                if (child is T typed)
+                    return typed;
+
+                var result = FindDescendant<T>(child);
+                if (result != null)
+                    return result;
+            }
+
+            return null;
+        }
+
+        private static Panel FindItemsHostPanel(ItemsControl itemsControl, int expectedChildCount)
+        {
+            if (itemsControl == null)
+                return null;
+
+            Panel best = null;
+
+            void Walk(DependencyObject node)
+            {
+                if (node == null)
+                    return;
+
+                if (node is Panel panel)
+                {
+                    // Prefer the panel that actually hosts the items
+                    if (panel.Children?.Count == expectedChildCount)
+                    {
+                        best = panel;
+                        return;
+                    }
+                }
+
+                var childCount = VisualTreeHelper.GetChildrenCount(node);
+                for (var i = 0; i < childCount && best == null; i++)
+                    Walk(VisualTreeHelper.GetChild(node, i));
+            }
+
+            Walk(itemsControl);
+            return best;
+        }
+
+        private int GetHiddenRolesCount(double collapsedMaxHeight, int roleCount)
+        {
+            // Ensure the visual tree is ready
+            RolesItemsControl.UpdateLayout();
+
+            var host = FindItemsHostPanel(RolesItemsControl, roleCount);
+            if (host == null || host.Children == null || host.Children.Count == 0)
+                return Math.Max(1, roleCount - 5);
+
+            var visibleCount = 0;
+
+            foreach (var child in host.Children.OfType<FrameworkElement>())
+            {
+                if (child.ActualHeight <= 0)
+                    continue;
+
+                // Position relative to the host panel
+                var topLeft = child.TransformToVisual(host).TransformPoint(new Point(0, 0));
+                var bottom = topLeft.Y + child.ActualHeight;
+
+                if (bottom <= collapsedMaxHeight + 0.5)
+                    visibleCount++;
+            }
+
+            var hidden = roleCount - visibleCount;
+            return hidden <= 0 ? 1 : hidden;
         }
 
         private void UpdateRolesDisplay()
         {
-            if (DataContext is not Unicord.Universal.Models.User.UserViewModel user || user.Roles == null)
+            if (RolesItemsControl == null || RolesExpandButton == null)
                 return;
 
-            var roleCount = user.Roles.Count;
-            
-            // Estimate ~5 roles fit in 2 rows
-            const int visibleRolesInCollapsedMode = 5;
-            
-            if (roleCount <= visibleRolesInCollapsedMode)
+            if (DataContext is not Unicord.Universal.Models.User.UserViewModel user || user.Roles == null)
             {
-                // Few roles, show all and hide expander
                 RolesExpandButton.Visibility = Visibility.Collapsed;
                 RolesItemsControl.MaxHeight = double.PositiveInfinity;
                 return;
             }
 
-            // Many roles, show expander
-            RolesExpandButton.Visibility = Visibility.Visible;
+            const double collapsedMaxHeight = 60; // ~2 rows at approximately 30px per row
 
-            if (_rolesExpanded)
+            // Determine whether content actually overflows the collapsed height.
+            // The previous implementation used a fixed role count estimate, which can be wrong
+            // depending on wrap width and role pill sizes.
+            var availableWidth = RolesItemsControl.ActualWidth;
+            if (availableWidth <= 0)
+                availableWidth = Root?.ActualWidth > 0 ? Root.ActualWidth : 280;
+
+            // Measure full (unclipped) desired height
+            var previousMaxHeight = RolesItemsControl.MaxHeight;
+            RolesItemsControl.MaxHeight = double.PositiveInfinity;
+            RolesItemsControl.Measure(new Windows.Foundation.Size(availableWidth, double.PositiveInfinity));
+            var fullHeight = RolesItemsControl.DesiredSize.Height;
+
+            var needsExpander = fullHeight > (collapsedMaxHeight + 0.5);
+
+            if (!needsExpander)
             {
+                // Everything fits already; show all and hide expander.
+                _rolesExpanded = true;
+                _rolesAutoExpanded = true;
+                RolesExpandButton.Visibility = Visibility.Collapsed;
                 RolesItemsControl.MaxHeight = double.PositiveInfinity;
-                RolesExpandIcon.Glyph = "\uE70E"; // ChevronUp
-                RolesMoreCount.Text = "Show less";
-                RolesExpandTooltip.Text = "Collapse Roles";
+                return;
             }
-            else
-            {
-                RolesItemsControl.MaxHeight = 60; // ~2 rows at approximately 30px per row
-                RolesExpandIcon.Glyph = "\uE70D"; // ChevronDown
-                var hiddenCount = roleCount - visibleRolesInCollapsedMode;
-                RolesMoreCount.Text = $"+{hiddenCount} more";
-                RolesExpandTooltip.Text = "Show All Roles";
-            }
+
+            // Many roles (or narrow layout): show expander
+            RolesExpandButton.Visibility = Visibility.Visible;
+            
+            // FORCE collapsed state - roles expander ALWAYS starts collapsed
+            RolesItemsControl.MaxHeight = collapsedMaxHeight;
+            RolesExpandIcon.Glyph = "\uE70D"; // ChevronDown
+            var hiddenCount = GetHiddenRolesCount(collapsedMaxHeight, user.Roles.Count);
+            RolesMoreCount.Text = $"+{hiddenCount} more";
+            RolesExpandTooltip.Text = "Show All Roles";
         }
 
         private void RolesExpandButton_Click(object sender, RoutedEventArgs e)
         {
-            _rolesExpanded = !_rolesExpanded;
-            UpdateRolesDisplay();
+            if (RolesItemsControl == null || RolesExpandButton == null)
+                return;
+
+            if (DataContext is not Unicord.Universal.Models.User.UserViewModel user || user.Roles == null)
+                return;
+
+            const double collapsedMaxHeight = 60;
+
+            // Toggle between collapsed and expanded
+            var isCurrentlyExpanded = RolesItemsControl.MaxHeight == double.PositiveInfinity;
+            
+            if (isCurrentlyExpanded)
+            {
+                // Currently expanded, collapse it
+                RolesItemsControl.MaxHeight = collapsedMaxHeight;
+                AnimateChevron(0); // Rotate to 0 degrees (down)
+                var hiddenCount = GetHiddenRolesCount(collapsedMaxHeight, user.Roles.Count);
+                RolesMoreCount.Text = $"+{hiddenCount} more";
+                RolesExpandTooltip.Text = "Show All Roles";
+            }
+            else
+            {
+                // Currently collapsed, expand it
+                RolesItemsControl.MaxHeight = double.PositiveInfinity;
+                AnimateChevron(-180); // Rotate to -180 degrees (up, clockwise)
+                RolesMoreCount.Text = "Show less";
+                RolesExpandTooltip.Text = "Collapse Roles";
+            }
+        }
+
+        private void AnimateChevron(double toAngle)
+        {
+            if (RolesExpandIconRotation == null)
+                return;
+
+            var storyboard = new Windows.UI.Xaml.Media.Animation.Storyboard();
+            var animation = new Windows.UI.Xaml.Media.Animation.DoubleAnimation
+            {
+                To = toAngle,
+                Duration = new Duration(TimeSpan.FromMilliseconds(200)),
+                EasingFunction = new Windows.UI.Xaml.Media.Animation.CubicEase { EasingMode = Windows.UI.Xaml.Media.Animation.EasingMode.EaseOut }
+            };
+            
+            Windows.UI.Xaml.Media.Animation.Storyboard.SetTarget(animation, RolesExpandIconRotation);
+            Windows.UI.Xaml.Media.Animation.Storyboard.SetTargetProperty(animation, "Angle");
+            storyboard.Children.Add(animation);
+            storyboard.Begin();
         }
 
         private void UpdateMutualDisplay()

--- a/Unicord.Universal/Controls/Flyouts/UserListContextFlyout.xaml
+++ b/Unicord.Universal/Controls/Flyouts/UserListContextFlyout.xaml
@@ -16,7 +16,7 @@
 
     <MenuFlyoutSeparator/>
 
-    <MenuFlyoutItem x:Uid="/Flyouts/Profile" Icon="OtherUser" Command="{Binding OpenUserOverlayCommand}" />
+    <MenuFlyoutItem x:Name="ProfileItem" x:Uid="/Flyouts/Profile" Icon="OtherUser" Click="ProfileItem_Click" />
     <MenuFlyoutItem x:Uid="/Flyouts/Message" Icon="Message" Command="{Binding MessageCommand}"/>
     
     <MenuFlyoutSeparator x:Name="managementSeparator" />

--- a/Unicord.Universal/Controls/Flyouts/UserListContextFlyout.xaml.cs
+++ b/Unicord.Universal/Controls/Flyouts/UserListContextFlyout.xaml.cs
@@ -1,4 +1,8 @@
-﻿using Windows.UI.Xaml.Controls;
+﻿using Unicord.Universal.Models.User;
+using Unicord.Universal.Pages.Overlay;
+using Unicord.Universal.Services;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 
 namespace Unicord.Universal.Controls.Flyouts
 {
@@ -7,6 +11,15 @@ namespace Unicord.Universal.Controls.Flyouts
         public UserListContextFlyout()
         {
             InitializeComponent();
+        }
+
+        private async void ProfileItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement element && element.DataContext is UserViewModel user)
+            {
+                await OverlayService.GetForCurrentView()
+                    .ShowOverlayAsync<UserInfoOverlayPage>(user);
+            }
         }
     }
 }

--- a/Unicord.Universal/Dialogs/ProfileOverlay.xaml
+++ b/Unicord.Universal/Dialogs/ProfileOverlay.xaml
@@ -9,122 +9,407 @@
     xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:media="using:Microsoft.UI.Xaml.Media"
     xmlns:lib="using:Microsoft.UI.Xaml.Controls"
-    xmlns:users="using:Unicord.Universal.Controls.Users" xmlns:guild="using:Unicord.Universal.Models.Guild"
-    x:DefaultBindMode="OneWay" mc:Ignorable="d" MaxWidth="550">
-
-    <UserControl.Resources>
-        <FontFamily x:Key="PivotHeaderItemFontFamily">Segoe UI Variable Display</FontFamily>
-        <FontWeight x:Key="PivotHeaderItemThemeFontWeight">Medium</FontWeight>
-    </UserControl.Resources>
+    xmlns:users="using:Unicord.Universal.Controls.Users"
+    xmlns:guild="using:Unicord.Universal.Models.Guild"
+    xmlns:user="using:Unicord.Universal.Models.User"
+    x:DefaultBindMode="OneWay" 
+    mc:Ignorable="d" 
+    MaxWidth="645"
+    Height="600">
 
     <Border VerticalAlignment="Center"
+            MinHeight="600"
             Background="{ThemeResource AcrylicInAppFillColorBaseBrush}"
             BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
-            BorderThickness="1,1,1,1"
-            CornerRadius="8">
-        <StackPanel>
-            <Border Background="{ThemeResource LayerFillColorAltBrush}"
-                    CornerRadius="8,8,0,0">
-                <Grid Padding="20">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="1*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
+            BorderThickness="1"
+            CornerRadius="{ThemeResource ProfileOverlay_Dialog_CornerRadius}">
+        <Grid>
+            <lib:NavigationView x:Name="NavView"
+                                PaneDisplayMode="LeftCompact"
+                                IsPaneOpen="False"
+                                IsBackButtonVisible="Collapsed"
+                                IsSettingsVisible="False"
+                                IsPaneToggleButtonVisible="False"
+                                CompactPaneLength="48"
+                                OpenPaneLength="190"
+                                SelectionChanged="NavView_SelectionChanged">
 
-                        <users:AvatarControl Width="96" Height="96"
-                                         Style="{StaticResource LargeAvatarWithPresenceStyle}"
-                                         Source="{x:Bind User.AvatarUrl}" 
-                                         Presence="{x:Bind User.Presence}"/>
-                        <StackPanel Margin="20,0,0,0" Grid.Column="1" VerticalAlignment="Center">
-                            <TextBlock Style="{ThemeResource TitleTextBlockStyle}" 
-                                       TextTrimming="CharacterEllipsis" 
-                                       TextWrapping="NoWrap"
-                                       FontFamily="Segoe UI Variable Display" 
-                                       Text="{x:Bind User.DisplayName, TargetNullValue='DisplayName'}">
+            <lib:NavigationView.MenuItems>
+                <lib:NavigationViewItem x:Name="OverviewItem"
+                                        Content="Overview"
+                                        Tag="overview">
+                    <lib:NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE946;" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
+                    </lib:NavigationViewItem.Icon>
+                </lib:NavigationViewItem>
+                
+                <lib:NavigationViewItem x:Name="ActivitiesItem"
+                                        Visibility="{x:Bind User.IsBot, Converter={StaticResource InverseBoolVisibilityConverter}, Mode=OneWay}"
+                                        Content="Activities"
+                                        Tag="activities">
+                    <lib:NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE163;" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
+                    </lib:NavigationViewItem.Icon>
+                </lib:NavigationViewItem>
+                
+                <lib:NavigationViewItem x:Name="MutualFriendsItem"
+                                        Content="Mutual Friends"
+                                        Tag="mutualfriends">
+                    <lib:NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE716;" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
+                    </lib:NavigationViewItem.Icon>
+                </lib:NavigationViewItem>
+                
+                <lib:NavigationViewItem x:Name="MutualServersItem"
+                                        x:Uid="/Dialogs/ProfileMutualServers"
+                                        Tag="mutual">
+                    <lib:NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE902;" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
+                    </lib:NavigationViewItem.Icon>
+                </lib:NavigationViewItem>
+            </lib:NavigationView.MenuItems>
 
-                            </TextBlock>
-                            <TextBlock x:Name="nicknameTextBlock"
-                                   Margin="0,0,4,0" 
-                                   TextWrapping="NoWrap" 
-                                   Visibility="{x:Bind User.Nickname, Converter={StaticResource BoolVisibilityConverter}, FallbackValue=Collapsed}"
-                                   Foreground="{x:Bind User.Color, Converter={StaticResource ColourBrushConverter}}" 
-                                   Text="{x:Bind User.DisplayName}"
-                                   Style="{ThemeResource SubtitleTextBlockStyle}"
-                                   FontFamily="Segoe UI Variable Display">
-                            </TextBlock>
-                        </StackPanel>
-                        <Grid Grid.Column="2" VerticalAlignment="Center" Margin="12,0,0,0">
+            <lib:NavigationView.FooterMenuItems>
+            </lib:NavigationView.FooterMenuItems>
+
+            <!-- Content Frame -->
+            <ScrollViewer Padding="20,20,20,0" VerticalScrollBarVisibility="Auto">
+                <Grid x:Name="ContentGrid" VerticalAlignment="Stretch">
+                    <!-- Overview / Profile Card -->
+                    <Grid x:Name="OverviewContent" Visibility="Collapsed">
+                        <Border Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                BorderThickness="1"
+                                CornerRadius="{ThemeResource ProfileOverlay_ProfileCard_CornerRadius}"
+                                VerticalAlignment="Stretch">
+                        <Grid>
                             <Grid.RowDefinitions>
-                                <RowDefinition Height="*"/>
-                                <RowDefinition Height="*"/>
+                                <!-- Banner -->
+                                <RowDefinition Height="135"/>
+                                <!-- Content -->
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <Button Style="{ThemeResource IconButtonStyle}" VerticalAlignment="Stretch" Content="&#xE8BD;" Command="{Binding MessageCommand}" />
-                            <Button Style="{ThemeResource IconButtonStyle}" VerticalAlignment="Stretch" Content="&#xE717;" Grid.Row="1" />
-                        </Grid>
-                    </Grid>
-                </Grid>
-            </Border>
-            <!--<Border Background="{ThemeResource LayerFillColorAltBrush}">
-                <Grid Grid.Row="1" 
-                      Visibility="{x:Bind User.Presence.Status, Converter={StaticResource HideOnNullConverter}, FallbackValue=Collapsed}">
-                    --><!--<controls:RichPresenceControl DataContext="{x:Bind _user.Presence.Activity}" Margin="8" />--><!--
-                </Grid>
-            </Border>-->
-            <Border>
-                <Grid MinHeight="200"
-                      Padding="0,0,0,20"
-                      BorderThickness="0,1,0,0"
-                      BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
-                    <Pivot SelectedIndex="0">
-                        <Pivot.HeaderTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Style="{ThemeResource SubtitleTextBlockStyle}"/>
-                            </DataTemplate>
-                        </Pivot.HeaderTemplate>
-                        <PivotItem x:Name="guildOverlay" x:Load="{x:Bind User.IsMember, Mode=OneTime}" Header="{x:Bind User.Guild.Name}">
-                            <StackPanel>
-                                <StackPanel x:Name="rolesList" 
-                                            Visibility="{x:Bind User.Roles, Converter={StaticResource BoolVisibilityConverter}}">
-                                    <TextBlock x:Uid="/Dialogs/ProfileRoles" Style="{ThemeResource FlyoutPickerTitleTextBlockStyle}" Margin="0,4"/>
-                                    <ItemsControl ItemTemplate="{StaticResource RoleTemplate}" ItemsSource="{x:Bind User.Roles}">
-                                        <ItemsControl.ItemsPanel>
-                                            <ItemsPanelTemplate>
-                                                <toolkit:WrapPanel VerticalSpacing="4" HorizontalSpacing="4"/>
-                                            </ItemsPanelTemplate>
-                                        </ItemsControl.ItemsPanel>
-                                    </ItemsControl>
+
+                            <!-- Banner area -->
+                            <Border Grid.Row="0"
+                                    Background="{ThemeResource LayerFillColorAltBrush}"
+                                    CornerRadius="{ThemeResource AccountsSettings_ProfileCard_BannerCornerRadius}" />
+
+                            <Button Grid.Row="0"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Top"
+                                    Margin="0,8,8,0"
+                                    Padding="4"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    ToolTipService.ToolTip="More"
+                                    Visibility="{x:Bind User.IsBot, Converter={StaticResource InverseBoolVisibilityConverter}, Mode=OneWay}">
+                                <Button.Content>
+                                    <FontIcon Glyph="&#xE10C;" FontFamily="{StaticResource SymbolThemeFontFamily}" />
+                                </Button.Content>
+                                <Button.Flyout>
+                                    <MenuFlyout>
+                                        <MenuFlyoutItem Text="Copy User ID" Click="CopyUserId_Click">
+                                            <MenuFlyoutItem.Icon>
+                                                <FontIcon Glyph="&#xEC7A;" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
+                                            </MenuFlyoutItem.Icon>
+                                        </MenuFlyoutItem>
+                                    </MenuFlyout>
+                                </Button.Flyout>
+                            </Button>
+
+                            <!-- Avatar + Name + Info -->
+                            <Grid Grid.Row="1" Margin="16,0,16,16">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <!-- Avatar overlapping banner -->
+                                <Grid Width="92" Height="92" Margin="0,-46,0,0" HorizontalAlignment="Left">
+                                    <Border CornerRadius="46"
+                                            BorderBrush="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                            BorderThickness="6"
+                                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" />
+
+                                    <users:AvatarControl Margin="6"
+                                                        Style="{ThemeResource LargeAvatarWithPresenceStyle}"
+                                                        Source="{x:Bind User.AvatarUrl}"
+                                                        Presence="{x:Bind User.Presence}" />
+                                </Grid>
+
+                                <!-- Names -->
+                                <StackPanel Grid.Row="1" Margin="0,12,0,0">
+                                            <TextBlock Style="{ThemeResource TitleTextBlockStyle}"
+                                              Text="{x:Bind User.DisplayName, TargetNullValue='DisplayName'}"
+                                                                                            Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                                              TextTrimming="CharacterEllipsis"
+                                              IsTextSelectionEnabled="True"
+                                              TextWrapping="NoWrap"/>
+                                            <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                              Text="{x:Bind User.Username}"
+                                              IsTextSelectionEnabled="True"
+                                              Style="{ThemeResource CaptionTextBlockStyle}"
+                                              TextTrimming="CharacterEllipsis"
+                                              TextWrapping="NoWrap"/>
                                 </StackPanel>
 
-                                <TextBlock x:Uid="/Dialogs/ProfileJoinedServer" Style="{ThemeResource FlyoutPickerTitleTextBlockStyle}" Margin="0,4"/>
-                                <TextBlock Text="{x:Bind User.JoinedAt, Converter={StaticResource DateTimeConverter}}"/>
-                            </StackPanel>
-                        </PivotItem>
-                        <PivotItem x:Uid="/Dialogs/ProfileMutualServers">
-                            <PivotItem.Content>
-                                <ListView x:Name="mutualServers" MaxHeight="180" SelectionMode="None" ItemsSource="{x:Bind User.MutualGuilds}">
-                                    <ListView.ItemTemplate>
-                                        <DataTemplate x:DataType="guild:GuildViewModel">
-                                            <Grid>
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                    <ColumnDefinition Width="*"/>
-                                                </Grid.ColumnDefinitions>
+                                <!-- Info section -->
+                                <StackPanel Grid.Row="2" Margin="0,16,0,0" Spacing="12">
+                                        <!-- Action buttons -->
+                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                            <Button Style="{ThemeResource AccentButtonStyle}" Content="&#xE717;" HorizontalAlignment="Stretch" Command="{Binding AddFriendCommand}">
+                                                <Button.ContentTemplate>
+                                                    <DataTemplate>
+                                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                                            <FontIcon Glyph="&#xE8FA;" FontSize="16"/>
+                                                            <TextBlock Text="Add Friend"/>
+                                                        </StackPanel>
+                                                    </DataTemplate>
+                                                </Button.ContentTemplate>
+                                            </Button>
+                                            <Button Content="&#xE8BD;" Command="{Binding MessageCommand}" HorizontalAlignment="Stretch">
+                                                <Button.ContentTemplate>
+                                                    <DataTemplate>
+                                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                                            <FontIcon Glyph="&#xE8BD;" FontSize="16"/>
+                                                            <TextBlock Text="Message"/>
+                                                        </StackPanel>
+                                                    </DataTemplate>
+                                                </Button.ContentTemplate>
+                                            </Button>
+                                        </StackPanel>
+                                        <!-- Member Since -->
+                                        <StackPanel>
+                                            <TextBlock Text="Member Since"
+                                                  Style="{ThemeResource BodyStrongTextBlockStyle}"/>
+                                            
+                                            <StackPanel Orientation="Horizontal" Spacing="12" Margin="0,4,0,0">
+                                                <!-- Account creation date -->
+                                                <StackPanel Orientation="Horizontal" Spacing="6">
+                                                    <Image Source="{StaticResource DiscordClyde}" 
+                                                           Width="16"
+                                                           Height="16"
+                                                           VerticalAlignment="Center"
+                                                           ToolTipService.ToolTip="Discord"/>
+                                                    <TextBlock Text="{x:Bind User.User.CreationTimestamp, Converter={StaticResource DateTimeConverter}}"
+                                                              Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                              IsTextSelectionEnabled="True"
+                                                              VerticalAlignment="Center"/>
+                                                </StackPanel>
+                                                
+                                                <!-- Separator dot (if guild member) -->
+                                                <Ellipse Width="4" 
+                                                        Height="4" 
+                                                        Fill="{ThemeResource TextFillColorSecondaryBrush}"
+                                                        VerticalAlignment="Center"
+                                                        Visibility="{x:Bind User.IsMember, Converter={StaticResource BoolVisibilityConverter}, Mode=OneWay}"/>
+                                                
+                                                <!-- Server join date (if guild member) -->
+                                                <StackPanel Orientation="Horizontal" 
+                                                           Spacing="6"
+                                                           Visibility="{x:Bind User.IsMember, Converter={StaticResource BoolVisibilityConverter}, Mode=OneWay}">
+                                                    <lib:PersonPicture DisplayName="{x:Bind User.Guild.Name}" 
+                                                                      ProfilePicture="{x:Bind User.Guild.Icon}" 
+                                                                      Width="16" 
+                                                                      Height="16"
+                                                                      ToolTipService.ToolTip="{x:Bind User.Guild.Name}"/>
+                                                    <TextBlock Text="{x:Bind User.JoinedAt, Converter={StaticResource DateTimeConverter}}"
+                                                              Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                              IsTextSelectionEnabled="True"
+                                                              VerticalAlignment="Center"/>
+                                                </StackPanel>
+                                            </StackPanel>
+                                        </StackPanel>
 
-                                                <lib:PersonPicture DisplayName="{x:Bind Name}" ProfilePicture="{x:Bind Icon}" Width="36" Height="36" Margin="0,4"/>
-                                                <TextBlock Grid.Column="1" Margin="12,0" Text="{x:Bind Name}" VerticalAlignment="Center"/>
-                                            </Grid>
-                                        </DataTemplate>
-                                    </ListView.ItemTemplate>
-                                </ListView>
-                            </PivotItem.Content>
-                        </PivotItem>
-                        <PivotItem x:Uid="/Dialogs/ProfileConnections">
-                        </PivotItem>
-                    </Pivot>
+                                        <!-- Roles (if guild member) -->
+                                        <StackPanel Visibility="{x:Bind User.Roles, Converter={StaticResource BoolVisibilityConverter}}">
+                                            <TextBlock x:Uid="/Dialogs/ProfileRoles" 
+                                                  Style="{ThemeResource BodyStrongTextBlockStyle}" 
+                                                  Margin="0,0,0,8"/>
+                                            <ItemsControl ItemTemplate="{StaticResource RoleTemplate}" 
+                                                     ItemsSource="{x:Bind User.Roles}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <toolkit:WrapPanel VerticalSpacing="4" HorizontalSpacing="4"/>
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </StackPanel>
+                            </Grid>
+                        </Grid>
+                    </Border>
                 </Grid>
-            </Border>
-        </StackPanel>
+
+                    <!-- Activities -->
+                    <Grid x:Name="ActivitiesContent" Visibility="Collapsed">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Text="Activities"
+                                  Style="{ThemeResource SubtitleTextBlockStyle}"/>
+
+                        <StackPanel Grid.Row="1"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    MaxWidth="360"
+                                    Spacing="12">
+                            <TextBlock TextAlignment="Center" TextWrapping="Wrap">
+                                <Run Text=""/>
+                                <Run Text="{x:Bind User.DisplayName, TargetNullValue='This user'}"/>
+                                <Run Text=" doesn't have any activity to share"/>
+                                <LineBreak/>
+                                <Run Text="here"/>
+                                <LineBreak/>
+                                <LineBreak/>
+                                <Run Text="No activity shared yet - drop them a friendly hello to"/>
+                                <LineBreak/>
+                                <Run Text="start chatting"/>
+                            </TextBlock>
+
+                            <Button Command="{Binding MessageCommand}"
+                                    HorizontalAlignment="Center">
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <FontIcon Glyph="&#xE8BD;" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="16"/>
+                                    <TextBlock Text="Message"/>
+                                </StackPanel>
+                            </Button>
+                        </StackPanel>
+                    </Grid>
+
+                    <!-- Mutual Friends -->
+                    <Grid x:Name="MutualFriendsContent" Visibility="Collapsed">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Text="Mutual Friends"
+                                  Style="{ThemeResource SubtitleTextBlockStyle}"/>
+
+                        <StackPanel Grid.Row="1"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    MaxWidth="360"
+                                    Spacing="12"
+                                    Visibility="{x:Bind User.MutualFriends, Converter={StaticResource InverseBoolVisibilityConverter}, Mode=OneWay}">
+                            <TextBlock TextAlignment="Center" TextWrapping="Wrap">
+                                <Run Text="You don't have any friends in common"/>
+                                <LineBreak/>
+                                <LineBreak/>
+                                <Run Text="Your friends haven't met their friends yet - time for a"/>
+                                <LineBreak/>
+                                <Run Text="legendary crossover!⚡"/>
+                            </TextBlock>
+                        </StackPanel>
+
+                        <ListView Grid.Row="1"
+                                 SelectionMode="None"
+                                 IsItemClickEnabled="True"
+                                 ItemClick="MutualFriendsList_ItemClick"
+                                 Margin="0,8"
+                                 ItemsSource="{x:Bind User.MutualFriends}"
+                                 Visibility="{x:Bind User.MutualFriends, Converter={StaticResource BoolVisibilityConverter}, Mode=OneWay}">
+                            <ListView.ItemContainerStyle>
+                                <Style TargetType="ListViewItem" BasedOn="{StaticResource DefaultListViewItemStyle}">
+                                    <Setter Property="Padding" Value="12,8"/>
+                                    <Setter Property="Margin" Value="0,2"/>
+                                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                    <Setter Property="Background" Value="Transparent"/>
+                                    <Setter Property="CornerRadius" Value="{ThemeResource RoleTemplate_CornerRadius}"/>
+                                </Style>
+                            </ListView.ItemContainerStyle>
+                            <ListView.ItemTemplate>
+                                <DataTemplate x:DataType="user:UserViewModel">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+
+                                        <users:AvatarControl Source="{x:Bind AvatarUrl}"
+                                                           Width="40"
+                                                           Height="40"/>
+                                        <TextBlock Grid.Column="1"
+                                                   Margin="12,0,0,0"
+                                                   Text="{x:Bind DisplayName}"
+                                                   VerticalAlignment="Center"
+                                                   Style="{ThemeResource BodyTextBlockStyle}"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ListView.ItemTemplate>
+                        </ListView>
+                    </Grid>
+
+                        <!-- Mutual Servers -->
+                        <Grid x:Name="MutualServersContent" Visibility="Collapsed">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+
+                        <TextBlock x:Uid="/Dialogs/ProfileMutualServersTitle"
+                                  Style="{ThemeResource SubtitleTextBlockStyle}"/>
+
+                        <StackPanel Grid.Row="1"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    MaxWidth="360"
+                                    Spacing="12"
+                                    Visibility="{x:Bind User.MutualGuilds, Converter={StaticResource InverseBoolVisibilityConverter}, Mode=OneWay}">
+                            <TextBlock TextAlignment="Center" TextWrapping="Wrap">
+                                <Run Text="You don't have any servers in common"/>
+                                <LineBreak/>
+                                <LineBreak/>
+                                <Run Text="Join the same servers to unlock shared emotes and more VC channels to hang in"/>
+                            </TextBlock>
+                        </StackPanel>
+
+                        <ListView Grid.Row="1"
+                                 SelectionMode="None"
+                                 IsItemClickEnabled="True"
+                                 ItemClick="MutualServersList_ItemClick"
+                                 Margin="0,8"
+                                 ItemsSource="{x:Bind User.MutualGuilds}"
+                                 Visibility="{x:Bind User.MutualGuilds, Converter={StaticResource BoolVisibilityConverter}, Mode=OneWay}">
+                            <ListView.ItemContainerStyle>
+                                <Style TargetType="ListViewItem" BasedOn="{StaticResource DefaultListViewItemStyle}">
+                                    <Setter Property="Padding" Value="12,8"/>
+                                    <Setter Property="Margin" Value="0,2"/>
+                                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                    <Setter Property="Background" Value="Transparent"/>
+                                    <Setter Property="CornerRadius" Value="{ThemeResource RoleTemplate_CornerRadius}"/>
+                                </Style>
+                            </ListView.ItemContainerStyle>
+                            <ListView.ItemTemplate>
+                                <DataTemplate x:DataType="guild:GuildViewModel">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+
+                                        <lib:PersonPicture DisplayName="{x:Bind Name}" 
+                                                          ProfilePicture="{x:Bind Icon}" 
+                                                          Width="40" 
+                                                          Height="40"/>
+                                        <TextBlock Grid.Column="1" 
+                                                  Margin="12,0,0,0" 
+                                                  Text="{x:Bind Name}" 
+                                                  VerticalAlignment="Center"
+                                                  Style="{ThemeResource BodyTextBlockStyle}"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ListView.ItemTemplate>
+                        </ListView>
+                        </Grid>
+                    </Grid>
+            </ScrollViewer>
+            </lib:NavigationView>
+        </Grid>
     </Border>
 </UserControl>

--- a/Unicord.Universal/Dialogs/ProfileOverlay.xaml
+++ b/Unicord.Universal/Dialogs/ProfileOverlay.xaml
@@ -158,8 +158,13 @@
                                 <!-- Info section -->
                                 <StackPanel Grid.Row="2" Margin="0,16,0,0" Spacing="12">
                                         <!-- Action buttons -->
-                                        <StackPanel Orientation="Horizontal" Spacing="8">
-                                            <Button Style="{ThemeResource AccentButtonStyle}" Content="&#xE717;" HorizontalAlignment="Stretch" Command="{Binding AddFriendCommand}">
+                                        <StackPanel Orientation="Horizontal">
+                                            <Button Style="{ThemeResource AccentButtonStyle}"
+                                                    Content="&#xE717;"
+                                                    HorizontalAlignment="Stretch"
+                                                    Command="{Binding AddFriendCommand}"
+                                                    Margin="0,0,8,0"
+                                                    Visibility="{x:Bind User.IsBot, Mode=OneWay, Converter={StaticResource InverseBoolVisibilityConverter}}">
                                                 <Button.ContentTemplate>
                                                     <DataTemplate>
                                                         <StackPanel Orientation="Horizontal" Spacing="8">

--- a/Unicord.Universal/Dialogs/ProfileOverlay.xaml
+++ b/Unicord.Universal/Dialogs/ProfileOverlay.xaml
@@ -61,7 +61,7 @@
                 </lib:NavigationViewItem>
                 
                 <lib:NavigationViewItem x:Name="MutualServersItem"
-                                        x:Uid="/Dialogs/ProfileMutualServers"
+                                        Content="Mutual Servers"
                                         Tag="mutual">
                     <lib:NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE902;" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
@@ -80,7 +80,7 @@
                         <Border Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
                                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                                 BorderThickness="1"
-                                CornerRadius="{ThemeResource ProfileOverlay_ProfileCard_CornerRadius}"
+                            CornerRadius="{ThemeResource ProfileOverlay_ProfileCard_CornerRadius}"
                                 VerticalAlignment="Stretch">
                         <Grid>
                             <Grid.RowDefinitions>

--- a/Unicord.Universal/Dialogs/ProfileOverlay.xaml.cs
+++ b/Unicord.Universal/Dialogs/ProfileOverlay.xaml.cs
@@ -1,14 +1,22 @@
-﻿using Unicord.Universal.Models.User;
+﻿using System.Linq;
+using DSharpPlus.Entities;
+using Unicord.Universal.Extensions;
+using Unicord.Universal.Models.User;
 using Unicord.Universal.Services;
+using Windows.ApplicationModel.DataTransfer;
 using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
+using Lib = Microsoft.UI.Xaml.Controls;
 
 namespace Unicord.Universal.Dialogs
 {
     public sealed partial class ProfileOverlay : UserControl
     {
+        private const double CompactThresholdWidth = 640;
+        private string _pendingNavigationTag;
+
         public UserViewModel User
         {
             get => (UserViewModel)GetValue(UserProperty);
@@ -22,11 +30,107 @@ namespace Unicord.Universal.Dialogs
         {
             var overlay = (ProfileOverlay)d;
             overlay.Bindings.Update();
+
+            overlay.ApplyPendingNavigationOrDefault();
         }
 
         public ProfileOverlay()
         {
             InitializeComponent();
+
+            SizeChanged += (_, __) => UpdatePaneMode();
+            
+            Loaded += (s, e) =>
+            {
+                ApplyPendingNavigationOrDefault();
+
+                UpdatePaneMode();
+            };
+        }
+
+        public void NavigateToSection(string tag)
+        {
+            _pendingNavigationTag = tag;
+            ApplyPendingNavigationOrDefault();
+        }
+
+        private void ApplyPendingNavigationOrDefault()
+        {
+            if (NavView == null)
+                return;
+
+            var tag = _pendingNavigationTag;
+            
+            Lib.NavigationViewItem targetItem = tag switch
+            {
+                "mutualfriends" => MutualFriendsItem,
+                "mutual" => MutualServersItem,
+                "activities" => ActivitiesItem,
+                _ => null
+            };
+
+            // If we have a pending navigation target, apply it
+            if (targetItem != null)
+            {
+                _pendingNavigationTag = null;
+                NavView.SelectedItem = targetItem;
+            }
+            // Only apply default Overview if nothing is selected yet
+            else if (NavView.SelectedItem == null && _pendingNavigationTag == null)
+            {
+                NavView.SelectedItem = OverviewItem;
+            }
+        }
+
+        private void UpdatePaneMode()
+        {
+            if (NavView == null)
+                return;
+
+            var isCompact = ActualWidth > 0 && ActualWidth < CompactThresholdWidth;
+
+            var desiredMode = isCompact
+                ? Lib.NavigationViewPaneDisplayMode.LeftCompact
+                : Lib.NavigationViewPaneDisplayMode.Left;
+
+            if (NavView.PaneDisplayMode != desiredMode)
+                NavView.PaneDisplayMode = desiredMode;
+
+            var desiredIsPaneOpen = !isCompact;
+            if (NavView.IsPaneOpen != desiredIsPaneOpen)
+                NavView.IsPaneOpen = desiredIsPaneOpen;
+
+            NavView.InvalidateMeasure();
+            NavView.UpdateLayout();
+        }
+
+        private void NavView_SelectionChanged(Lib.NavigationView sender, Lib.NavigationViewSelectionChangedEventArgs args)
+        {
+            if (args.SelectedItemContainer?.Tag is not string tag)
+                return;
+
+            // Hide all content
+            OverviewContent.Visibility = Visibility.Collapsed;
+            ActivitiesContent.Visibility = Visibility.Collapsed;
+            MutualFriendsContent.Visibility = Visibility.Collapsed;
+            MutualServersContent.Visibility = Visibility.Collapsed;
+
+            // Show selected content
+            switch (tag)
+            {
+                case "overview":
+                    OverviewContent.Visibility = Visibility.Visible;
+                    break;
+                case "activities":
+                    ActivitiesContent.Visibility = Visibility.Visible;
+                    break;
+                case "mutualfriends":
+                    MutualFriendsContent.Visibility = Visibility.Visible;
+                    break;
+                case "mutual":
+                    MutualServersContent.Visibility = Visibility.Visible;
+                    break;
+            }
         }
 
         private void DropShadowPanel_PreviewKeyUp(object sender, KeyRoutedEventArgs e)
@@ -36,6 +140,62 @@ namespace Unicord.Universal.Dialogs
                 OverlayService.GetForCurrentView()
                     .CloseOverlay();
             }
+        }
+
+        private async void MutualServersList_ItemClick(object sender, ItemClickEventArgs e)
+        {
+            if (e.ClickedItem is Unicord.Universal.Models.Guild.GuildViewModel guild)
+            {
+                OverlayService.GetForCurrentView().CloseOverlay();
+                
+                if (App.LocalSettings.Read(Constants.ENABLE_GUILD_BROWSING, Constants.ENABLE_GUILD_BROWSING_DEFAULT))
+                {
+                    // Navigate to guild browsing view
+                    var discordPage = Window.Current.Content.FindChild<Pages.DiscordPage>();
+                    if (discordPage != null)
+                    {
+                        discordPage.LeftSidebarFrame.Navigate(typeof(Pages.Subpages.GuildChannelListPage), guild.Guild);
+                    }
+                }
+                else
+                {
+                    // Navigate to previously selected channel or first accessible text channel
+                    var channelId = App.RoamingSettings.Read($"GuildPreviousChannels::{guild.Guild.Id}", 0UL);
+                    if (!guild.Guild.Channels.TryGetValue(channelId, out var channel) || (!channel.IsAccessible() || !channel.IsText()))
+                    {
+                        channel = guild.Guild.Channels.Values
+                            .Where(c => c.IsAccessible())
+                            .Where(c => c.IsText())
+                            .OrderBy(c => c.Position)
+                            .FirstOrDefault();
+                    }
+
+                    if (channel != null)
+                    {
+                        await DiscordNavigationService.GetForCurrentView()
+                            .NavigateAsync(channel);
+                    }
+                }
+            }
+        }
+
+        private async void MutualFriendsList_ItemClick(object sender, ItemClickEventArgs e)
+        {
+            if (e.ClickedItem is Unicord.Universal.Models.User.UserViewModel friendUser)
+            {
+                await OverlayService.GetForCurrentView()
+                    .ReplaceOverlayWithAnimationAsync<Pages.Overlay.UserInfoOverlayPage>(friendUser);
+            }
+        }
+
+        private void CopyUserId_Click(object sender, RoutedEventArgs e)
+        {
+            if (User == null)
+                return;
+
+            var dataPackage = new DataPackage();
+            dataPackage.SetText(User.Id.ToString());
+            Clipboard.SetContent(dataPackage);
         }
     }
 }

--- a/Unicord.Universal/MainPage.xaml.cs
+++ b/Unicord.Universal/MainPage.xaml.cs
@@ -348,6 +348,24 @@ namespace Unicord.Universal
                 HideOverlayStoryboard.Begin();
         }
 
+        public Task HideCustomOverlayAsync()
+        {
+            if (CustomOverlayGrid.Visibility == Visibility.Collapsed)
+                return Task.CompletedTask;
+
+            var tcs = new TaskCompletionSource<object>();
+
+            void Handler(object sender, object e)
+            {
+                HideOverlayStoryboard.Completed -= Handler;
+                tcs.TrySetResult(null);
+            }
+
+            HideOverlayStoryboard.Completed += Handler;
+            HideOverlayStoryboard.Begin();
+            return tcs.Task;
+        }
+
         private void OverlayBackdrop_Tapped(object sender, TappedRoutedEventArgs e)
         {
             OverlayService.GetForCurrentView()

--- a/Unicord.Universal/Models/User/UserViewModel.cs
+++ b/Unicord.Universal/Models/User/UserViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Input;
 using DSharpPlus.Entities;
+using DSharpPlus.Enums;
 using DSharpPlus.EventArgs;
 using CommunityToolkit.Mvvm.Messaging;
 using Unicord.Universal.Commands;
@@ -149,6 +150,16 @@ namespace Unicord.Universal.Models.User
                 return _mutualGuilds;
             }
         }
+
+        // Mutual friends placeholder since its currently not populated in Unicord.
+        public List<UserViewModel> MutualFriends
+            => null;
+
+        public int MutualFriendsCount
+            => MutualFriends?.Count ?? 0;
+
+        public bool HasMutualInfo
+            => !IsCurrent && (MutualGuilds?.Count ?? 0) > 0;
 
         public List<RoleViewModel> Roles
             => Member != null ?

--- a/Unicord.Universal/Pages/Overlay/UserInfoOverlayPage.xaml.cs
+++ b/Unicord.Universal/Pages/Overlay/UserInfoOverlayPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Unicord.Universal.Models.User;
+﻿using System;
+using Unicord.Universal.Models.User;
 using Unicord.Universal.Services;
 using Windows.Foundation;
 using Windows.UI.Xaml.Controls;
@@ -25,7 +26,17 @@ namespace Unicord.Universal.Pages.Overlay
         {
             base.OnNavigatedTo(e);
 
-            userInfoOverlay.User = (UserViewModel)e.Parameter;
+            if (e.Parameter is UserViewModel user)
+            {
+                userInfoOverlay.User = user;
+                return;
+            }
+
+            if (e.Parameter is System.ValueTuple<UserViewModel, string> tuple)
+            {
+                userInfoOverlay.User = tuple.Item1;
+                userInfoOverlay.NavigateToSection(tuple.Item2);
+            }
         }
     }
 }

--- a/Unicord.Universal/Resources/en-GB/Dialogs.resw
+++ b/Unicord.Universal/Resources/en-GB/Dialogs.resw
@@ -210,13 +210,19 @@
   <data name="PinMessageDialog.Title" xml:space="preserve">
     <value>Pin this message?</value>
   </data>
-  <data name="ProfileConnections.Header" xml:space="preserve">
+  <data name="ProfileConnections.Content" xml:space="preserve">
     <value>Connections</value>
   </data>
   <data name="ProfileJoinedServer.Text" xml:space="preserve">
     <value>Joined Server</value>
   </data>
+  <data name="ProfileMutualServers.Content" xml:space="preserve">
+    <value>Mutual Servers</value>
+  </data>
   <data name="ProfileMutualServers.Header" xml:space="preserve">
+    <value>Mutual Servers</value>
+  </data>
+  <data name="ProfileMutualServersTitle.Text" xml:space="preserve">
     <value>Mutual Servers</value>
   </data>
   <data name="ProfileRoles.Text" xml:space="preserve">

--- a/Unicord.Universal/Resources/en-US/Dialogs.resw
+++ b/Unicord.Universal/Resources/en-US/Dialogs.resw
@@ -210,13 +210,19 @@
   <data name="PinMessageDialog.Title" xml:space="preserve">
     <value>Pin this message?</value>
   </data>
-  <data name="ProfileConnections.Header" xml:space="preserve">
+  <data name="ProfileConnections.Content" xml:space="preserve">
     <value>Connections</value>
   </data>
   <data name="ProfileJoinedServer.Text" xml:space="preserve">
     <value>Joined Server</value>
   </data>
+  <data name="ProfileMutualServers.Content" xml:space="preserve">
+    <value>Mutual Servers</value>
+  </data>
   <data name="ProfileMutualServers.Header" xml:space="preserve">
+    <value>Mutual Servers</value>
+  </data>
+  <data name="ProfileMutualServersTitle.Text" xml:space="preserve">
     <value>Mutual Servers</value>
   </data>
   <data name="ProfileRoles.Text" xml:space="preserve">

--- a/Unicord.Universal/Resources/fr/Dialogs.resw
+++ b/Unicord.Universal/Resources/fr/Dialogs.resw
@@ -201,13 +201,19 @@
   <data name="PinMessageDialog.Title" xml:space="preserve">
     <value>Épingler ce message?</value>
   </data>
-  <data name="ProfileConnections.Header" xml:space="preserve">
+  <data name="ProfileConnections.Content" xml:space="preserve">
     <value>Profils connectés</value>
   </data>
   <data name="ProfileJoinedServer.Text" xml:space="preserve">
     <value>Serveurs rejoints</value>
   </data>
+  <data name="ProfileMutualServers.Content" xml:space="preserve">
+    <value>Serveurs en commun</value>
+  </data>
   <data name="ProfileMutualServers.Header" xml:space="preserve">
+    <value>Serveurs en commun</value>
+  </data>
+  <data name="ProfileMutualServersTitle.Text" xml:space="preserve">
     <value>Serveurs en commun</value>
   </data>
   <data name="ProfileRoles.Text" xml:space="preserve">

--- a/Unicord.Universal/Resources/ja-JP/Dialogs.resw
+++ b/Unicord.Universal/Resources/ja-JP/Dialogs.resw
@@ -210,13 +210,19 @@
   <data name="PinMessageDialog.Title" xml:space="preserve">
     <value>このメッセージをピン止めしますか？</value>
   </data>
-  <data name="ProfileConnections.Header" xml:space="preserve">
+  <data name="ProfileConnections.Content" xml:space="preserve">
     <value>連携</value>
   </data>
   <data name="ProfileJoinedServer.Text" xml:space="preserve">
     <value>サーバー参加日</value>
   </data>
+  <data name="ProfileMutualServers.Content" xml:space="preserve">
+    <value>共通のサーバー</value>
+  </data>
   <data name="ProfileMutualServers.Header" xml:space="preserve">
+    <value>共通のサーバー</value>
+  </data>
+  <data name="ProfileMutualServersTitle.Text" xml:space="preserve">
     <value>共通のサーバー</value>
   </data>
   <data name="ProfileRoles.Text" xml:space="preserve">

--- a/Unicord.Universal/Resources/ru-RU/Dialogs.resw
+++ b/Unicord.Universal/Resources/ru-RU/Dialogs.resw
@@ -210,13 +210,19 @@
   <data name="PinMessageDialog.Title" xml:space="preserve">
     <value>Закрепить это сообщение?</value>
   </data>
-  <data name="ProfileConnections.Header" xml:space="preserve">
+  <data name="ProfileConnections.Content" xml:space="preserve">
     <value>Связи</value>
   </data>
   <data name="ProfileJoinedServer.Text" xml:space="preserve">
     <value>Присоединился к серверу</value>
   </data>
+  <data name="ProfileMutualServers.Content" xml:space="preserve">
+    <value>Общие серверы</value>
+  </data>
   <data name="ProfileMutualServers.Header" xml:space="preserve">
+    <value>Общие серверы</value>
+  </data>
+  <data name="ProfileMutualServersTitle.Text" xml:space="preserve">
     <value>Общие серверы</value>
   </data>
   <data name="ProfileRoles.Text" xml:space="preserve">

--- a/Unicord.Universal/Services/OverlayService.cs
+++ b/Unicord.Universal/Services/OverlayService.cs
@@ -69,6 +69,30 @@ namespace Unicord.Universal.Services
             }
         }
 
+        public async Task ReplaceOverlayWithAnimationAsync<T>(object model = null) where T : Page, IOverlay, new()
+        {
+            if (App.LocalSettings.Read("WindowedOverlays", false))
+            {
+                // In a separate window overlay, just navigate within the window to get a page transition.
+                if (Window.Current.Content is Frame frame)
+                {
+                    frame.Navigate(typeof(T), model, new EntranceNavigationTransitionInfo());
+                }
+
+                return;
+            }
+
+            if (_overlayVisible)
+            {
+                _systemNavigationManager.BackRequested -= OnBackRequested;
+                await _mainPage.HideCustomOverlayAsync();
+                _overlayVisible = false;
+            }
+
+            // Re-open (plays the overlay open storyboard)
+            await ShowOverlayAsync<T>(model);
+        }
+
         internal void CloseOverlay()
         {
             if (App.LocalSettings.Read("WindowedOverlays", false))

--- a/Unicord.Universal/Themes/Controls/Messages.xaml
+++ b/Unicord.Universal/Themes/Controls/Messages.xaml
@@ -881,7 +881,8 @@
                                         Width="16"
                                         Height="16"
                                         Margin="0,0,4,0"
-                                        Grid.Column="1">
+                                        Grid.Column="1"
+                                        Tapped="Avatar_Tapped">
                             <Ellipse.Fill>
                                 <ImageBrush>
                                     <ImageBrush.ImageSource>
@@ -894,7 +895,12 @@
                             </Ellipse.Fill>
                         </Ellipse>
 
-                        <controls:UsernameControl Grid.Column="2" FontWeight="Bold" User="{x:Bind ReferencedMessage.Author}" FontSize="12" IconSize="12"/>
+                        <controls:UsernameControl Grid.Column="2"
+                                                  FontWeight="Bold"
+                                                  User="{x:Bind ReferencedMessage.Author}"
+                                                  FontSize="12"
+                                                  IconSize="12"
+                                                  Tapped="UsernameControl_Tapped" />
 
                         <controls:MarkdownTextBlock x:Name="ReplyMarkdown"
                                                 Grid.Column="3"
@@ -921,6 +927,7 @@
                                  DataContextChanged="ImageContainer_DataContextChanged"
                                  Width="36"
                                  Height="36"
+                                 Tapped="Avatar_Tapped"
                                  VerticalAlignment="Top">
                             <Ellipse.Fill>
                                 <ImageBrush x:Name="ProfileImageBrush">
@@ -943,7 +950,11 @@
                             <StackPanel x:Name="AuthorContainer" 
                                         x:Load="{x:Bind converters:Static.IsNot(State, messages:MessageViewModelState.Collapsed),Mode=OneWay}"   
                                         Orientation="Horizontal" Grid.Row="0">
-                                <controls:UsernameControl FontWeight="Bold" User="{x:Bind Author}" FontSize="14" IconSize="14" />
+                                <controls:UsernameControl FontWeight="Bold"
+                                                          User="{x:Bind Author}"
+                                                          FontSize="14"
+                                                          IconSize="14"
+                                                          Tapped="UsernameControl_Tapped" />
 
                                 <TextBlock Margin="8,1" 
                                            x:Phase="4"                               

--- a/Unicord.Universal/Themes/Controls/Messages.xaml.cs
+++ b/Unicord.Universal/Themes/Controls/Messages.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Unicord.Universal.Models.Messages;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Shapes;
@@ -40,6 +42,22 @@ namespace Unicord.Universal.Resources.Controls
                 DecodePixelWidth = 36,
                 DecodePixelType = DecodePixelType.Logical
             };
+        }
+
+        private void UsernameControl_Tapped(object sender, TappedRoutedEventArgs e)
+        {
+            if (sender is FrameworkElement element && element.DataContext is Unicord.Universal.Models.User.UserViewModel user)
+            {
+                Unicord.Universal.Utilities.AdaptiveFlyoutUtilities.ShowAdaptiveFlyout<Unicord.Universal.Controls.Flyouts.UserFlyout>(user, element);
+            }
+        }
+
+        private void Avatar_Tapped(object sender, TappedRoutedEventArgs e)
+        {
+            if (sender is FrameworkElement element && element.DataContext is MessageViewModel message && message.Author != null)
+            {
+                Unicord.Universal.Utilities.AdaptiveFlyoutUtilities.ShowAdaptiveFlyout<Unicord.Universal.Controls.Flyouts.UserFlyout>(message.Author, element, FlyoutPlacementMode.Right);
+            }
         }
     }
 }

--- a/Unicord.Universal/Themes/Styles/Fluent.xaml
+++ b/Unicord.Universal/Themes/Styles/Fluent.xaml
@@ -28,7 +28,10 @@
                     <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
 
                     <CornerRadius x:Key="AccountsSettings_ProfileCard_CornerRadius">0</CornerRadius>
+                    <CornerRadius x:Key="ProfileOverlay_Dialog_CornerRadius">0</CornerRadius>
+                    <CornerRadius x:Key="ProfileOverlay_ProfileCard_CornerRadius">0</CornerRadius>
                     <CornerRadius x:Key="AccountsSettings_ProfileCard_BannerCornerRadius">0</CornerRadius>
+                    <CornerRadius x:Key="RoleTemplate_CornerRadius">0</CornerRadius>
 
                     <!-- General -->
 

--- a/Unicord.Universal/Themes/Styles/Performance.xaml
+++ b/Unicord.Universal/Themes/Styles/Performance.xaml
@@ -34,6 +34,9 @@
 
                     <CornerRadius x:Key="AccountsSettings_ProfileCard_CornerRadius">0</CornerRadius>
                     <CornerRadius x:Key="AccountsSettings_ProfileCard_BannerCornerRadius">0</CornerRadius>
+                    <CornerRadius x:Key="ProfileOverlay_Dialog_CornerRadius">0</CornerRadius>
+                    <CornerRadius x:Key="ProfileOverlay_ProfileCard_CornerRadius">0</CornerRadius>
+                    <CornerRadius x:Key="RoleTemplate_CornerRadius">0</CornerRadius>
 
                     <SolidColorBrush x:Key="General_Page_BackgroundBrush" Color="{ThemeResource BackgroundPrimaryColour}"/>
 

--- a/Unicord.Universal/Themes/Styles/SunValley.xaml
+++ b/Unicord.Universal/Themes/Styles/SunValley.xaml
@@ -22,7 +22,7 @@
                     <CornerRadius x:Key="AccountsSettings_ProfileCard_CornerRadius">8</CornerRadius>
                     <CornerRadius x:Key="AccountsSettings_ProfileCard_BannerCornerRadius">8,8,0,0</CornerRadius>
                     <CornerRadius x:Key="ProfileOverlay_Dialog_CornerRadius">8</CornerRadius>
-                    <CornerRadius x:Key="ProfileOverlay_ProfileCard_CornerRadius">8</CornerRadius>
+                    <CornerRadius x:Key="ProfileOverlay_ProfileCard_CornerRadius">8,8,0,0</CornerRadius>
                     <CornerRadius x:Key="RoleTemplate_CornerRadius">4</CornerRadius>
 
                     <Style x:Key="CleanButtonStyle" TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">

--- a/Unicord.Universal/Themes/Styles/SunValley.xaml
+++ b/Unicord.Universal/Themes/Styles/SunValley.xaml
@@ -21,6 +21,9 @@
 
                     <CornerRadius x:Key="AccountsSettings_ProfileCard_CornerRadius">8</CornerRadius>
                     <CornerRadius x:Key="AccountsSettings_ProfileCard_BannerCornerRadius">8,8,0,0</CornerRadius>
+                    <CornerRadius x:Key="ProfileOverlay_Dialog_CornerRadius">8</CornerRadius>
+                    <CornerRadius x:Key="ProfileOverlay_ProfileCard_CornerRadius">8</CornerRadius>
+                    <CornerRadius x:Key="RoleTemplate_CornerRadius">4</CornerRadius>
 
                     <Style x:Key="CleanButtonStyle" TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
                         <Setter Property="Background" Value="Transparent"/>

--- a/Unicord.Universal/Themes/Templates.xaml
+++ b/Unicord.Universal/Themes/Templates.xaml
@@ -251,12 +251,17 @@
 
     <DataTemplate x:Key="RoleTemplate" x:DataType="userVMs:RoleViewModel">
         <Border BorderThickness="1"
-                BorderBrush="{x:Bind Color}" 
-                Padding="4,4,4,4"
-                CornerRadius="2"
-                MinWidth="24">
-            <TextBlock Foreground="{x:Bind Color}" 
-                       FontSize="12" Text="{x:Bind Name}" VerticalAlignment="Center" TextAlignment="Center"/>
+                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
+                Padding="6,4,8,4"
+                CornerRadius="{ThemeResource RoleTemplate_CornerRadius}">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <Ellipse Width="12" Height="12" 
+                         Fill="{x:Bind Color}"
+                         VerticalAlignment="Center"/>
+                <TextBlock FontSize="12" 
+                           Text="{x:Bind Name}" 
+                           VerticalAlignment="Center"/>
+            </StackPanel>
         </Border>
     </DataTemplate>
 
@@ -380,8 +385,7 @@
 
             <i:Interaction.Behaviors>
                 <core:DataTriggerBehavior Binding="{x:Bind IsExpanded}"
-                                              ComparisonCondition="Equal"
-                                              Value="True">
+                                          Value="True">
                     <media1:ControlStoryboardAction>
                         <media1:ControlStoryboardAction.Storyboard>
                             <Storyboard>
@@ -404,8 +408,7 @@
                     </media1:ControlStoryboardAction>
                 </core:DataTriggerBehavior>
                 <core:DataTriggerBehavior Binding="{x:Bind IsExpanded}"
-                                              ComparisonCondition="Equal"
-                                              Value="False">
+                                          Value="False">
                     <media1:ControlStoryboardAction>
                         <media1:ControlStoryboardAction.Storyboard>
                             <Storyboard>

--- a/Unicord.Universal/Utilities/AdaptiveFlyout.cs
+++ b/Unicord.Universal/Utilities/AdaptiveFlyout.cs
@@ -1,14 +1,22 @@
 ﻿using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
 
 namespace Unicord.Universal.Utilities
 {
     public abstract class AdaptiveFlyout : UserControl
     {
+        internal FlyoutBase HostFlyout { get; set; }
+
         public AdaptiveFlyout(object param)
         {
             DataContext = param;
+        }
+
+        protected void CloseHostFlyout()
+        {
+            HostFlyout?.Hide();
         }
     }
 
@@ -24,8 +32,17 @@ namespace Unicord.Universal.Utilities
             //else
             //{
                 var flyoutContainer = new Flyout() { Content = flyout };
+                flyout.HostFlyout = flyoutContainer;
                 flyoutContainer.ShowAt(showAt);
             //}
+        }
+
+        public static void ShowAdaptiveFlyout<TFlyout>(object parameter, FrameworkElement showAt, FlyoutPlacementMode placement) where TFlyout : AdaptiveFlyout
+        {
+            var flyout = (AdaptiveFlyout)Activator.CreateInstance(typeof(TFlyout), new[] { parameter });
+            var flyoutContainer = new Flyout() { Content = flyout, Placement = placement };
+            flyout.HostFlyout = flyoutContainer;
+            flyoutContainer.ShowAt(showAt);
         }
     }
 }

--- a/Unicord.Universal/Utilities/EmojiUtilities.cs
+++ b/Unicord.Universal/Utilities/EmojiUtilities.cs
@@ -42,7 +42,7 @@ namespace Unicord.Universal.Utilities
                 e.IsAvailable
                 && (!hasSearchTerm || culture.IndexOf(e.Name, searchTerm, CompareOptions.IgnoreCase) >= 0);
 
-            if (hasNitro && (channel.Channel.IsPrivate || channel.Channel.CurrentPermissions.HasPermission(Permissions.UseExternalEmojis)))
+            if (hasNitro && (channel == null || channel.Channel.IsPrivate || channel.Channel.CurrentPermissions.HasPermission(Permissions.UseExternalEmojis)))
             {
                 // all availiable emoji 
                 var guildOrder = GetOrderedGuildsList();
@@ -55,7 +55,7 @@ namespace Unicord.Universal.Utilities
             else
             {
                 // just this server's emoji
-                if (channel.Guild == null)
+                if (channel == null || channel.Guild == null)
                     return [];
                 var group = new EmojiGroup(channel.Guild.Guild, channel.Guild.Guild.Emojis.Values.Where(FilterEmoji));
 


### PR DESCRIPTION
This PR modernizes the Userflyout and Profile Overlay UI with Win11-style design and New Discord-inspired layout. Features:

- Redesigned ProfileOverlay with NavigationView structure featuring Overview, Activities, Mutual Friends, and Mutual Servers sections with adaptive pane display modes (compact for narrow widths, expanded for wider views)
- Enhanced UserFlyout UI with improved layout and functionality
- Added clickable username controls and avatars in message templates to show UserFlyout when tapped
- Implemented async overlay hiding and ReplaceOverlayWithAnimationAsync method for smooth transitions between overlays
- Added logic for users to tap person icons to display user flyout
- Updated role pill styling to match new Discord design
- Implemented mutual servers list with click-to-navigate functionality (opens guild browsing or channels)
- Added "Copy User ID" functionality to profile overlay

Tested on: Windows 11 Version 25H2 (OS Build 26220.7535) x64

Preview:
- User Flyout
<img width="372" height="437" alt="Screenshot 2026-01-19 211230" src="https://github.com/user-attachments/assets/9552dcf7-8938-46cb-bdc8-7504e9731cae" />
<img width="380" height="435" alt="image" src="https://github.com/user-attachments/assets/84f1934b-86bf-41a0-9401-003efc1a81aa" />

- Profile Overlay
<img width="1007" height="869" alt="image" src="https://github.com/user-attachments/assets/c55fd3f3-226d-41c6-b71e-6f6aa15edb96" />
<img width="754" height="679" alt="image" src="https://github.com/user-attachments/assets/644a280d-c032-4050-aed6-acd9bc0f0468" />
<img width="776" height="695" alt="image" src="https://github.com/user-attachments/assets/d6994549-0864-4376-be25-68f80cfaeb2f" />
<img width="783" height="707" alt="image" src="https://github.com/user-attachments/assets/e1c10615-df66-49e9-b475-49bf12a5e343" />